### PR TITLE
Fix mobile scrolling and autocorrect text duplication

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -522,7 +522,12 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <div class="terminal-mobile-input-row">
+              <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
+              <button class="mobile-send-btn">Send</button>
+            </div>
             <div class="terminal-mobile-toolbar">
+              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
               <button class="toolbar-keyboard" data-key="keyboard" title="Toggle keyboard">&#9000; Type</button>
               <button class="toolbar-send" data-key="enter">Enter</button>
               <button data-key="tab">Tab</button>
@@ -533,7 +538,6 @@
               <button data-key="up">&#8593;</button>
               <button data-key="down">&#8595;</button>
               <button class="toolbar-upload" data-key="upload" title="Upload image">&#128247;</button>
-              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
             </div>
           </div>
           <div class="terminal-pane terminal-pane-empty" id="term-pane-1" data-slot="1" hidden>
@@ -548,7 +552,12 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <div class="terminal-mobile-input-row">
+              <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
+              <button class="mobile-send-btn">Send</button>
+            </div>
             <div class="terminal-mobile-toolbar">
+              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
               <button class="toolbar-keyboard" data-key="keyboard" title="Toggle keyboard">&#9000; Type</button>
               <button class="toolbar-send" data-key="enter">Enter</button>
               <button data-key="tab">Tab</button>
@@ -559,7 +568,6 @@
               <button data-key="up">&#8593;</button>
               <button data-key="down">&#8595;</button>
               <button class="toolbar-upload" data-key="upload" title="Upload image">&#128247;</button>
-              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
             </div>
           </div>
           <div class="terminal-pane terminal-pane-empty" id="term-pane-2" data-slot="2" hidden>
@@ -574,7 +582,12 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <div class="terminal-mobile-input-row">
+              <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
+              <button class="mobile-send-btn">Send</button>
+            </div>
             <div class="terminal-mobile-toolbar">
+              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
               <button class="toolbar-keyboard" data-key="keyboard" title="Toggle keyboard">&#9000; Type</button>
               <button class="toolbar-send" data-key="enter">Enter</button>
               <button data-key="tab">Tab</button>
@@ -585,7 +598,6 @@
               <button data-key="up">&#8593;</button>
               <button data-key="down">&#8595;</button>
               <button class="toolbar-upload" data-key="upload" title="Upload image">&#128247;</button>
-              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
             </div>
           </div>
           <div class="terminal-pane terminal-pane-empty" id="term-pane-3" data-slot="3" hidden>
@@ -600,7 +612,12 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <div class="terminal-mobile-input-row">
+              <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
+              <button class="mobile-send-btn">Send</button>
+            </div>
             <div class="terminal-mobile-toolbar">
+              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
               <button class="toolbar-keyboard" data-key="keyboard" title="Toggle keyboard">&#9000; Type</button>
               <button class="toolbar-send" data-key="enter">Enter</button>
               <button data-key="tab">Tab</button>
@@ -611,7 +628,6 @@
               <button data-key="up">&#8593;</button>
               <button data-key="down">&#8595;</button>
               <button class="toolbar-upload" data-key="upload" title="Upload image">&#128247;</button>
-              <button class="toolbar-reader" data-key="reader" title="Full-screen scrollable reader">&#128196; Read</button>
             </div>
           </div>
         </div>

--- a/src/web/public/styles-mobile.css
+++ b/src/web/public/styles-mobile.css
@@ -570,6 +570,14 @@
     overscroll-behavior: contain;
     -webkit-overflow-scrolling: touch;
     touch-action: pan-y;
+    /* Hide scrollbar on mobile — touch scrolling replaces it,
+       and the thin bar conflicts with Chrome's edge gestures */
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  .terminal-pane.mobile-active .xterm-viewport::-webkit-scrollbar {
+    display: none;
   }
 
   /* xterm screen layer (canvas) — pointer-events toggled by JS:
@@ -712,6 +720,64 @@
   }
 
   .terminal-mobile-toolbar .toolbar-send:active {
+    opacity: 0.8;
+  }
+
+  /* ── Mobile input row (replaces xterm textarea for autocorrect-safe typing) ── */
+  .terminal-mobile-input-row {
+    display: none;
+    gap: 6px;
+    padding: 6px 8px;
+    background: var(--mantle);
+    border-top: 1px solid var(--surface0);
+    flex-shrink: 0;
+    align-items: center;
+  }
+
+  .terminal-mobile-input-row.active {
+    display: flex;
+  }
+
+  .terminal-mobile-input-row input {
+    flex: 1;
+    min-width: 0;
+    height: 40px;
+    padding: 6px 12px;
+    border-radius: 8px;
+    background: var(--surface0);
+    border: 1px solid var(--surface1);
+    color: var(--text-primary);
+    font-size: 15px;
+    font-family: 'JetBrains Mono', 'Cascadia Code', Consolas, monospace;
+    outline: none;
+    -webkit-appearance: none;
+  }
+
+  .terminal-mobile-input-row input:focus {
+    border-color: var(--blue);
+    box-shadow: 0 0 0 2px rgba(137, 180, 250, 0.2);
+  }
+
+  .terminal-mobile-input-row .mobile-send-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 56px;
+    height: 40px;
+    padding: 6px 14px;
+    border-radius: 8px;
+    background: var(--green);
+    color: var(--crust);
+    border: none;
+    font-weight: 600;
+    font-size: 13px;
+    font-family: 'JetBrains Mono', 'Cascadia Code', Consolas, monospace;
+    cursor: pointer;
+    flex-shrink: 0;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .terminal-mobile-input-row .mobile-send-btn:active {
     opacity: 0.8;
   }
 }


### PR DESCRIPTION
## Summary
- **Scroll fix**: Hidden xterm scrollbar on mobile (conflicts with Chrome's right-edge gestures) and added `stopPropagation()` to capture-phase touch handlers so xterm.js can't fight the manual scroll
- **Input fix**: Added a dedicated mobile input field (`<input>`) that bypasses xterm.js's hidden textarea entirely — autocorrect, swipe typing, and tap-to-correct suggestions all work without text duplication
- **LAN/Tailscale access**: CORS and CSP headers are now dynamic based on the request host, so the GUI works when accessed via Tailscale or other LAN IPs (not just localhost)

## Context
On mobile Chrome, xterm.js's hidden textarea doesn't handle autocorrect properly — when the keyboard replaces text (via composition events or `insertReplacementText`), xterm processes both the original keystrokes and the replacement, causing entire phrases to duplicate. This is a fundamental mismatch between how mobile keyboards expect textareas to work and how xterm.js uses its textarea as a transient input pipe.

Rather than trying to patch xterm.js's event handling (which proved unreliable across keyboard implementations), the mobile "Type" button now toggles a real `<input>` field above the toolbar. Text is composed there with full autocorrect support, then sent to the PTY on Enter/Send.

## Test plan
- [ ] Open on mobile Chrome, tap Type, verify the input field appears and autocorrect works without duplication
- [ ] Verify scroll mode still works smoothly (no xterm scrollbar visible, momentum scrolling intact)
- [ ] Access via Tailscale/LAN IP — verify WebSocket connects and terminals work
- [ ] Desktop behavior unchanged (input field is mobile-only via media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)