### PR TITLE
Fix terminal scrollback duplication on WebSocket reconnect

### DIFF
--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -513,10 +513,9 @@ class PtySessionManager {
       return;
     }
 
-    // Add client to the session's client set
-    session.clients.add(ws);
-
-    // Replay scrollback buffer so the client sees existing output
+    // Replay scrollback buffer BEFORE adding to broadcast set.
+    // This ensures the client receives the full historical output first,
+    // then starts receiving only NEW live data — no interleaving.
     if (session.scrollback.length > 0) {
       const replay = session.scrollback.join('');
       try {
@@ -527,6 +526,9 @@ class PtySessionManager {
         // ignore
       }
     }
+
+    // NOW add client to the broadcast set for live PTY data
+    session.clients.add(ws);
 
     // If session already exited, notify this client
     if (!session.alive) {


### PR DESCRIPTION
Thanks for developing and sharing this helpful tool. I found duplicate content when long session is reconnected. So I try this fix.

## Summary
- **Server (`pty-manager.js`)**: Replay scrollback buffer BEFORE adding the client to the broadcast set. Previously, the client was added first, allowing live PTY data to interleave with the historical scrollback replay — causing duplicated content for long sessions.
- **Client (`terminal.js`)**: Cancel pending write timers (`_writeRaf`, `_bgFlushTimer`) and clear the write buffer before `term.reset()` on reconnect. A stale background flush timer could fire after the terminal was cleared, writing old data back onto the clean screen.