### PR TITLE
fix: skip git worktree add if worktree path already registered

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -4815,11 +4815,22 @@ app.post('/api/worktree-tasks', requireAuth, async (req, res) => {
       branchExists = true;
     } catch {}
 
-    const args = ['worktree', 'add'];
-    if (!branchExists) args.push('-b', branch);
-    args.push(worktreePath);
-    if (branchExists) args.push(branch);
-    await gitExec(args, root);
+    // Check if this worktree path is already registered with git (e.g. from a
+    // previous attempt that succeeded at the git level but failed later).
+    // If so, skip `git worktree add` to avoid the "already exists" fatal error.
+    let worktreeAlreadyRegistered = false;
+    try {
+      const listOut = await gitExec(['worktree', 'list', '--porcelain'], root);
+      worktreeAlreadyRegistered = listOut.includes(`worktree ${worktreePath}`);
+    } catch {}
+
+    if (!worktreeAlreadyRegistered) {
+      const args = ['worktree', 'add'];
+      if (!branchExists) args.push('-b', branch);
+      args.push(worktreePath);
+      if (branchExists) args.push(branch);
+      await gitExec(args, root);
+    }
 
     // 1.5. Run init hooks (copy_files and init_script) if configured
     const initHooks = store.getWorktreeInitHooks();


### PR DESCRIPTION
## Problem

When creating a worktree task, if a previous attempt succeeded at the `git worktree add` step but failed afterwards (e.g. session creation error), any retry would produce a fatal error from git:

```
fatal: '/path/to/repo-wt/feat-branch-name' already exists
```

This left the user stuck — they could never successfully create the task because every attempt would fail at the git step.

## Fix

Before calling `git worktree add`, check `git worktree list --porcelain` to see if the target path is already registered as a worktree. If it is, skip the `add` call entirely and proceed with the rest of task/session creation normally.

This allows retries to succeed cleanly when the worktree was partially created by a previous attempt.

## Testing

- Create a worktree task that fails after the git step
- Retry — should now proceed instead of erroring with "already exists"
- Normal (first-time) worktree creation is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)