### PR TITLE
fix: pass workspaceId inside object to store.createSession

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -3219,7 +3219,8 @@ app.post('/api/sessions/:id/spinoff-batch', requireAuth, async (req, res) => {
 
         // Create session
         const sessionName = (t.branch || t.title).replace(/^feat\//, '') + ' (spinoff)';
-        const newSession = store.createSession(workspaceId, {
+        const newSession = store.createSession({
+          workspaceId,
           name: sessionName,
           workingDir: worktreePath,
           command: 'claude',
@@ -4855,7 +4856,8 @@ app.post('/api/worktree-tasks', requireAuth, async (req, res) => {
 
     // 2. Create a session in this workspace pointing at the worktree
     const sessionName = branch.replace(/^feat\//, '') + ' (worktree task)';
-    const session = store.createSession(workspaceId, {
+    const session = store.createSession({
+      workspaceId,
       name: sessionName,
       workingDir: worktreePath,
       command: 'claude',


### PR DESCRIPTION
## Problem

`store.createSession` takes a single destructured object argument:

```js
createSession({ name, workspaceId, workingDir, command, ... })
```

Two call sites in `server.js` were incorrectly passing `workspaceId` as a separate first argument:

```js
// Wrong — workspaceId ends up undefined inside the function
store.createSession(workspaceId, { name, workingDir, command })
```

This caused `this._state.workspaces[undefined]` to always return falsy, so `createSession` returned `null` and the endpoint responded with `"Failed to create session"` every time.

Affected endpoints:
- `POST /api/worktree-tasks` (worktree task creation)
- Spinoff task creation flow

## Fix

Move `workspaceId` inside the options object at both call sites, matching the function signature and the correct usage already present elsewhere in the codebase.

## Testing

- Create a worktree task via the UI — session should be created successfully
- Spinoff task creation should also work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)