### PR TITLE
fix: don't add --continue when working directory has no Claude history

### DIFF
--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -154,11 +154,30 @@ class PtySessionManager {
     if (resumeSessionId) {
       fullCommand += ' --resume ' + resumeSessionId;
     } else if (cwd && !newSession) {
-      // No explicit session to resume - use --continue to pick up most recent
-      // conversation in this working directory. On a fresh dir with no history,
-      // Claude will start a new conversation (same as bare `claude`).
-      // Skip --continue when newSession is true (user explicitly wants a fresh session).
-      fullCommand += ' --continue';
+      // Only add --continue when there is actually conversation history for this
+      // working directory. `claude --continue` exits with code 1 ("No conversation
+      // found to continue") on a fresh directory — e.g. a brand-new git worktree.
+      // Scan ~/.claude/projects/ for any JSONL file whose encoded path matches cwd.
+      let hasHistory = false;
+      try {
+        const claudeDir = path.join(os.homedir(), '.claude', 'projects');
+        if (fs.existsSync(claudeDir)) {
+          const normalizedCwd = cwd.replace(/[/\\]/g, path.sep);
+          const match = fs.readdirSync(claudeDir).find(d => {
+            try {
+              return decodeURIComponent(d).replace(/[/\\]/g, path.sep) === normalizedCwd;
+            } catch (_) { return false; }
+          });
+          if (match) {
+            const projDir = path.join(claudeDir, match);
+            hasHistory = fs.readdirSync(projDir).some(f => f.endsWith('.jsonl'));
+          }
+        }
+      } catch (_) { /* filesystem error — fall through, don't add --continue */ }
+      if (hasHistory) {
+        fullCommand += ' --continue';
+      }
+      // If no history, run bare `claude` — starts a fresh session without error.
     }
     if (bypassPermissions) {
       fullCommand += ' --dangerously-skip-permissions';


### PR DESCRIPTION
## Problem

`claude --continue` exits with code 1 ("No conversation found to continue") when there is no prior session JSONL file for the working directory. This broke every brand-new worktree task: the terminal would open and connect, then immediately exit with that error.

The comment in the code said Claude would start fresh on an empty directory — but that's not how `--continue` works (or the CLI behavior changed).

## Fix

Before appending `--continue`, scan `~/.claude/projects/` for a directory matching the session's working directory and check whether it contains any `.jsonl` files. Only add `--continue` if history actually exists.

Falls back safely: if the projects directory doesn't exist or the scan fails, `--continue` is omitted and Claude starts fresh.

## Files Changed

- `src/web/pty-manager.js` — check for JSONL history before adding `--continue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)