### PR TITLE
Replace password-in-URL with one-time startup token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,7 @@ CWM_PASSWORD=mypassword npx myrlin-workbook
 
 Password lookup order: `CWM_PASSWORD` env var > `~/.myrlin/config.json` > `./state/config.json` > auto-generate.
 
-You can also auto-login by passing the password as a URL query parameter:
-
-```
-http://localhost:3456?password=mypassword
-```
-
-The password is automatically stripped from the URL bar after login to avoid leaking in browser history or referrer headers. The startup console message includes a clickable URL with the password pre-filled, so you can simply click it to open and authenticate in one step.
+On startup, the console prints a clickable URL with a one-time token (e.g., `http://127.0.0.1:3456?token=<random>`). Click it to auto-login — the token is single-use and expires after 60 seconds, so it's safe even if it appears in terminal logs. The token is stripped from the URL bar immediately after login.
 
 ### Prerequisites
 

--- a/src/gui.js
+++ b/src/gui.js
@@ -16,7 +16,7 @@
 const { getStore } = require('./state/store');
 const { startServer, getPtyManager } = require('./web/server');
 const { backupFrontend } = require('./web/backup');
-const { AUTH_PASSWORD } = require('./web/auth');
+const { generateStartupToken } = require('./web/auth');
 
 // ─── Initialize Store ──────────────────────────────────────
 
@@ -93,7 +93,8 @@ const port = parseInt(process.env.PORT, 10) || 3456;
 const host = process.env.CWM_HOST || '127.0.0.1';
 const server = startServer(port, host);
 
-const authUrl = `http://${host}:${port}?password=${encodeURIComponent(AUTH_PASSWORD)}`;
+const startupToken = generateStartupToken();
+const authUrl = `http://${host}:${port}?token=${encodeURIComponent(startupToken)}`;
 console.log(`CWM GUI running at ${authUrl}`);
 console.log('Press Ctrl+C to stop.');
 

--- a/src/web/auth.js
+++ b/src/web/auth.js
@@ -25,6 +25,7 @@ const os = require('os');
 
 // ─── Configuration ─────────────────────────────────────────
 const TOKEN_BYTE_LENGTH = 32;
+const STARTUP_TOKEN_TTL_MS = 60 * 1000; // 60 seconds
 const HOME_CONFIG_DIR = path.join(os.homedir(), '.myrlin');
 const HOME_CONFIG_FILE = path.join(HOME_CONFIG_DIR, 'config.json');
 const LOCAL_CONFIG_DIR = path.join(__dirname, '..', '..', 'state');
@@ -165,6 +166,33 @@ const AUTH_PASSWORD = loadPassword();
 // for a local dev-tool).
 const activeTokens = new Set();
 
+// ─── One-Time Startup Tokens ──────────────────────────────
+// Map of token → { createdAt, used }. Single-use, short-lived tokens
+// embedded in the startup URL so the browser can auto-login without
+// exposing the actual password.
+const startupTokens = new Map();
+
+/**
+ * Generate a one-time startup token for URL-based auto-login.
+ * The token is single-use and expires after STARTUP_TOKEN_TTL_MS.
+ * @returns {string} The generated token
+ */
+function generateStartupToken() {
+  const token = crypto.randomBytes(TOKEN_BYTE_LENGTH).toString('hex');
+  startupTokens.set(token, { createdAt: Date.now(), used: false });
+  return token;
+}
+
+// Clean up expired/used startup tokens every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [token, entry] of startupTokens) {
+    if (entry.used || now - entry.createdAt > STARTUP_TOKEN_TTL_MS) {
+      startupTokens.delete(token);
+    }
+  }
+}, 5 * 60 * 1000).unref();
+
 // ─── Helpers ───────────────────────────────────────────────
 
 /**
@@ -263,6 +291,67 @@ function setupAuth(app) {
   });
 
   /**
+   * POST /api/auth/token-login
+   * Body: { token: string }
+   * Exchanges a one-time startup token for a session Bearer token.
+   * The startup token must exist, not be expired (60s TTL), and not already used.
+   * Returns: { success: true, token: string } or { success: false, error: string }
+   */
+  app.post('/api/auth/token-login', (req, res) => {
+    // Rate limiting (same as login)
+    const clientIp = req.ip || req.connection.remoteAddress || 'unknown';
+    if (isRateLimited(clientIp)) {
+      return res.status(429).json({
+        success: false,
+        error: 'Too many login attempts. Try again in 1 minute.',
+      });
+    }
+
+    const { token: startupToken } = req.body || {};
+
+    if (!startupToken || typeof startupToken !== 'string') {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing or invalid token field in request body.',
+      });
+    }
+
+    const entry = startupTokens.get(startupToken);
+    if (!entry) {
+      return res.status(403).json({
+        success: false,
+        error: 'Invalid or expired startup token.',
+      });
+    }
+
+    // Check expiry
+    if (Date.now() - entry.createdAt > STARTUP_TOKEN_TTL_MS) {
+      startupTokens.delete(startupToken);
+      return res.status(403).json({
+        success: false,
+        error: 'Startup token has expired.',
+      });
+    }
+
+    // Check single-use
+    if (entry.used) {
+      return res.status(403).json({
+        success: false,
+        error: 'Startup token has already been used.',
+      });
+    }
+
+    // Mark as used and remove from map (single-use)
+    startupTokens.delete(startupToken);
+
+    // Issue a session token
+    const sessionToken = generateToken();
+    activeTokens.add(sessionToken);
+
+    return res.json({ success: true, token: sessionToken });
+  });
+
+  /**
    * POST /api/auth/logout
    * Requires Authorization: Bearer <token>
    * Removes the token from the active set.
@@ -305,5 +394,6 @@ module.exports = {
   setupAuth,
   requireAuth,
   isValidToken,
-  AUTH_PASSWORD,
+  generateStartupToken,
+  _startupTokens: startupTokens,
 };

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1811,41 +1811,42 @@ class CWMApp {
 
 
 
+  async _initializeApp() {
+    this.showApp();
+    this.initDragAndDrop();
+    this.initTerminalResize();
+    this.initTerminalGroups();
+    this.initTerminalPaneSwipe();
+    this.initNotesEditor();
+    this.initAIInsights();
+    await this.loadAll();
+    this.connectSSE();
+    this.startConflictChecks();
+    this.checkForUpdates();
+  }
+
   async init() {
     // Restore sidebar width & collapse state from localStorage
     this.restoreSidebarState();
 
-    // Auto-login via URL ?password=xxx parameter
+    // Auto-login via URL ?token=xxx parameter (one-time startup token)
     const params = new URLSearchParams(window.location.search);
-    const urlPassword = params.get('password');
-    if (urlPassword) {
-      // Always strip password from URL to avoid leaking in browser history/referrer
+    const urlToken = params.get('token');
+    if (urlToken) {
+      // Always strip token from URL to avoid leaking in browser history/referrer
       window.history.replaceState({}, '', window.location.pathname);
-      if (!this.state.token) {
-        try {
-          await this.login(urlPassword);
-          return; // login() handles showApp/loadAll/connectSSE
-        } catch {
-          // Fall through to normal login form
-        }
+      try {
+        await this.tokenLogin(urlToken);
+        return; // tokenLogin() handles showApp/loadAll/connectSSE
+      } catch {
+        // Fall through to normal login form
       }
     }
 
     if (this.state.token) {
       const valid = await this.checkAuth();
       if (valid) {
-        this.showApp();
-        this.initDragAndDrop();
-        this.initTerminalResize();
-        this.initTerminalGroups();
-        // Initialize mobile swipe gestures for pane switching
-        this.initTerminalPaneSwipe();
-        this.initNotesEditor();
-        this.initAIInsights();
-        await this.loadAll();
-        this.connectSSE();
-        this.startConflictChecks();
-        this.checkForUpdates();
+        await this._initializeApp();
       } else {
         this.state.token = null;
         localStorage.removeItem('cwm_token');
@@ -1922,18 +1923,7 @@ class CWMApp {
       if (data.success && data.token) {
         this.state.token = data.token;
         localStorage.setItem('cwm_token', data.token);
-        this.showApp();
-        this.initDragAndDrop();
-        this.initTerminalResize();
-        this.initTerminalGroups();
-        // Initialize mobile swipe gestures for pane switching
-        this.initTerminalPaneSwipe();
-        this.initNotesEditor();
-        this.initAIInsights();
-        await this.loadAll();
-        this.connectSSE();
-        this.startConflictChecks();
-        this.checkForUpdates();
+        await this._initializeApp();
       } else {
         this.els.loginError.textContent = 'Invalid password. Please try again.';
       }
@@ -1942,6 +1932,17 @@ class CWMApp {
     } finally {
       this.els.loginBtn.classList.remove('loading');
       this.els.loginBtn.disabled = false;
+    }
+  }
+
+  async tokenLogin(startupToken) {
+    const data = await this.api('POST', '/api/auth/token-login', { token: startupToken });
+    if (data.success && data.token) {
+      this.state.token = data.token;
+      localStorage.setItem('cwm_token', data.token);
+      await this._initializeApp();
+    } else {
+      throw new Error(data.error || 'Token login failed');
     }
   }
 

--- a/test/run.js
+++ b/test/run.js
@@ -637,52 +637,84 @@ test('handles binary files in numstat (- marks)', () => {
 });
 
 // ──────────────────────────────────────────────────────
-// URL Auto-Login
+// URL Auto-Login (One-Time Startup Token)
 // ──────────────────────────────────────────────────────
 
-suite('URL Auto-Login - Parameter Extraction');
+suite('URL Auto-Login - Token Extraction');
 
 /**
- * Extract password from URL query params and build the cleaned URL.
- * Mirrors the logic added to app.js init() method.
- * Returns { password, cleanUrl } or { password: null } if no param.
+ * Extract one-time token from URL query params and build the cleaned URL.
+ * Mirrors the logic in app.js init() method.
+ * Returns { token, cleanUrl } or { token: null } if no param.
  */
-function extractUrlPassword(url) {
+function extractUrlToken(url) {
   const parsed = new URL(url, 'http://localhost');
-  const password = parsed.searchParams.get('password');
-  if (!password) return { password: null, cleanUrl: null };
+  const token = parsed.searchParams.get('token');
+  if (!token) return { token: null, cleanUrl: null };
   // Build clean URL (pathname only, no query)
-  return { password, cleanUrl: parsed.pathname };
+  return { token, cleanUrl: parsed.pathname };
 }
 
-test('extracts password from ?password=xxx', () => {
-  const result = extractUrlPassword('http://localhost:40932?password=test123');
-  assertEqual(result.password, 'test123');
+test('extracts token from ?token=xxx', () => {
+  const result = extractUrlToken('http://localhost:40932?token=abc123def');
+  assertEqual(result.token, 'abc123def');
 });
 
-test('returns clean URL without password param', () => {
-  const result = extractUrlPassword('http://localhost:40932?password=test123');
+test('returns clean URL without token param', () => {
+  const result = extractUrlToken('http://localhost:40932?token=abc123def');
   assertEqual(result.cleanUrl, '/');
 });
 
-test('returns null password when no param present', () => {
-  const result = extractUrlPassword('http://localhost:40932');
-  assertEqual(result.password, null);
+test('returns null token when no param present', () => {
+  const result = extractUrlToken('http://localhost:40932');
+  assertEqual(result.token, null);
 });
 
-test('returns null password for empty password param', () => {
-  const result = extractUrlPassword('http://localhost:40932?password=');
-  assertEqual(result.password, null);
+test('returns null token for empty token param', () => {
+  const result = extractUrlToken('http://localhost:40932?token=');
+  assertEqual(result.token, null);
 });
 
-test('handles password with special characters', () => {
-  const result = extractUrlPassword('http://localhost:40932?password=p%40ss%23word');
-  assertEqual(result.password, 'p@ss#word');
+test('handles token with special characters', () => {
+  const result = extractUrlToken('http://localhost:40932?token=abc%2Bdef%3D123');
+  assertEqual(result.token, 'abc+def=123');
 });
 
-test('preserves pathname when stripping password', () => {
-  const result = extractUrlPassword('http://localhost:40932/some/path?password=abc');
+test('preserves pathname when stripping token', () => {
+  const result = extractUrlToken('http://localhost:40932/some/path?token=abc');
   assertEqual(result.cleanUrl, '/some/path');
+});
+
+// ──────────────────────────────────────────────────────
+// Server-Side Startup Token
+// ──────────────────────────────────────────────────────
+
+suite('Startup Token - Generation & Validation');
+
+const { generateStartupToken, _startupTokens } = require('../src/web/auth');
+
+test('generateStartupToken returns a non-empty string', () => {
+  const token = generateStartupToken();
+  assert(typeof token === 'string' && token.length > 0, 'Token should be a non-empty string');
+});
+
+test('generateStartupToken returns unique tokens each call', () => {
+  const t1 = generateStartupToken();
+  const t2 = generateStartupToken();
+  assert(t1 !== t2, 'Tokens should be unique');
+});
+
+test('generated token is stored in startupTokens map', () => {
+  const token = generateStartupToken();
+  assert(_startupTokens.has(token), 'Token should be stored in startupTokens map');
+  const entry = _startupTokens.get(token);
+  assert(typeof entry.createdAt === 'number', 'Should have createdAt timestamp');
+  assertEqual(entry.used, false);
+});
+
+test('AUTH_PASSWORD is not exported from auth module', () => {
+  const authExports = require('../src/web/auth');
+  assertEqual(authExports.AUTH_PASSWORD, undefined, 'AUTH_PASSWORD should not be exported');
 });
 
 // ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses review feedback — replaces plaintext password in the startup URL with a one-time, time-limited token.

- **One-time startup token**: `generateStartupToken()` creates a random token stored in a `startupTokens` Map with 60s TTL and single-use enforcement. The startup URL now uses `?token=<random>` instead of `?password=<actual-password>`.
- **New endpoint**: `POST /api/auth/token-login` exchanges a startup token for a session Bearer token. Rate-limited, validates expiry and single-use. Token is deleted from the map immediately after use.
- **`AUTH_PASSWORD` no longer exported** — stays module-private in auth.js, reducing attack surface.
- **Memory cleanup**: background interval (every 5 min) removes expired/used startup tokens, matching the existing `loginAttempts` cleanup pattern.
- **Extracted `_initializeApp()`** in app.js to eliminate 3x copy-paste of the post-login init sequence (was duplicated in `init()`, `login()`, and `tokenLogin()`).
- **Stale token handling**: token login is always attempted when a URL token is present, even if a cached session token exists in localStorage (handles server restart gracefully).

### Security improvements over v1
| Concern | Before (v1) | After (v2) |
|---------|-------------|------------|
| Console logs | Plaintext password in URL | One-time token (safe to leak) |
| `AUTH_PASSWORD` scope | Exported, accessible from other modules | Module-private |
| Timing window | Password in `window.location.search` until `replaceState` | Token is single-use — even if captured, can't be reused |
| Replay attack | Same URL works forever | Token expires after 60s and is deleted after first use |

## Files changed
- `src/web/auth.js` — token generation, cleanup interval, `POST /api/auth/token-login`, removed `AUTH_PASSWORD` export
- `src/gui.js` — uses `generateStartupToken()` instead of `AUTH_PASSWORD`
- `src/web/public/app.js` — handles `?token=`, new `tokenLogin()` method, extracted `_initializeApp()`
- `test/run.js` — updated 6 URL extraction tests (password→token), added 4 server-side token tests
- `README.md` — updated documentation

## Test plan
- [x] `npm test` passes (52/52 tests)
- [x] Start server: `CWM_PASSWORD=test123 PORT=40932 node src/gui.js`
- [x] Console prints URL with `?token=<random>` (not `?password=`)
- [x] Click URL — auto-login works via token-login endpoint
- [x] Reuse same token — rejected ("Invalid or expired startup token")
- [x] Invalid token — rejected
- [x] Normal form login with password still works
- [x] `AUTH_PASSWORD` is `undefined` in auth.js exports