### PR TITLE
fix: prevent Ctrl+V double-paste in terminal panes

### DIFF
--- a/src/web/public/terminal.js
+++ b/src/web/public/terminal.js
@@ -374,8 +374,12 @@ class TerminalPane {
 
         // Ctrl+V / Cmd+V: paste from clipboard via WebSocket
         // Using explicit clipboard read instead of relying on browser paste event,
-        // which doesn't always fire reliably through xterm's hidden textarea
+        // which doesn't always fire reliably through xterm's hidden textarea.
+        // e.preventDefault() is required: returning false only stops xterm from
+        // handling the key but does NOT prevent the browser from also firing
+        // beforeinput(insertFromPaste) → paste, which would double-send via WS.
         if (mod && e.key === 'v') {
+          e.preventDefault();
           this.pasteFromClipboard();
           return false;
         }


### PR DESCRIPTION
## Problem

Every `Ctrl+V` paste in a terminal pane sends the clipboard content twice to the PTY.

## Root Cause

`attachCustomKeyEventHandler` returning `false` tells xterm.js not to process the keydown event, but it does **not** call `e.preventDefault()` on the underlying DOM event. The browser therefore continues with its native paste action and fires:

```
beforeinput(insertFromPaste) → paste
```

The existing `beforeinput` handler on xterm's hidden textarea intercepts this and sends the pasted text through the WebSocket a second time — resulting in every `Ctrl+V` delivering the text twice.

## Fix

Call `e.preventDefault()` in the `Ctrl+V` branch of the custom key handler. This cancels the browser's native paste action before it starts, so only `pasteFromClipboard()` sends the text. `Cmd+V` on macOS is covered by the same branch via `e.metaKey`.

```js
if (mod && e.key === 'v') {
  e.preventDefault();   // ← added
  this.pasteFromClipboard();
  return false;
}
```

## Testing

- `Ctrl+V` with text in clipboard → pastes once
- `Cmd+V` on macOS → pastes once
- Right-click → Paste → still works (unaffected path)
- Bracketed paste mode preserved (pasteFromClipboard wraps in `\x1b[200~...\x1b[201~`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)