### PR TITLE
feat: session titles in discovered panel + cwd extraction fixes

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -3109,10 +3109,16 @@ class CWMApp {
           this.showToast('Select or create a project first', 'warning');
           return;
         }
-        // Use project folder name as friendly default name instead of raw UUID
-        const projectName = projectPath ? projectPath.split('\\').pop() || projectPath.split('/').pop() || sessionName : sessionName;
-        const shortId = sessionName.length > 8 ? sessionName.substring(0, 8) : sessionName;
-        const friendlyName = projectName + ' (' + shortId + ')';
+        // Prefer custom title from Claude session, fall back to folder name + short UUID
+        const customTitle = this.getProjectSessionTitle(sessionName);
+        let friendlyName;
+        if (customTitle) {
+          friendlyName = customTitle;
+        } else {
+          const projectName = projectPath ? projectPath.split('\\').pop() || projectPath.split('/').pop() || sessionName : sessionName;
+          const shortId = sessionName.length > 8 ? sessionName.substring(0, 8) : sessionName;
+          friendlyName = projectName + ' (' + shortId + ')';
+        }
         this.api('POST', '/api/sessions', {
           name: friendlyName,
           workspaceId: this.state.activeWorkspace.id,
@@ -9592,6 +9598,11 @@ class CWMApp {
       const sessionItems = sessions.map(s => {
         const sessName = s.name || 'unnamed';
         const claudeTitle = s.title || null;
+        if (claudeTitle && !this.getProjectSessionTitle(sessName)) {
+          const titles = JSON.parse(localStorage.getItem('cwm_projectSessionTitles') || '{}');
+          titles[sessName] = claudeTitle;
+          localStorage.setItem('cwm_projectSessionTitles', JSON.stringify(titles));
+        }
         const storedTitle = this.getProjectSessionTitle(sessName);
         const displayName = storedTitle || claudeTitle || (sessName.length > 24 ? sessName.substring(0, 24) + '...' : sessName);
         const sessSize = s.size ? this.formatSize(s.size) : '';

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -7230,8 +7230,10 @@ class CWMApp {
           !p.dirExists ? '<span class="discover-badge discover-badge-missing">missing</span>' : '',
         ].filter(Boolean).join(' ');
 
-        const latestSessionId = p.sessions && p.sessions.length > 0 ? p.sessions[0].name : '';
-        return `<div class="discover-row" data-path="${this.escapeHtml(p.realPath)}" data-name="${this.escapeHtml(name)}" data-session-id="${this.escapeHtml(latestSessionId)}">
+        const latestSession = p.sessions && p.sessions.length > 0 ? p.sessions[0] : null;
+        const latestSessionId = latestSession ? latestSession.name : '';
+        const latestSessionTitle = latestSession ? (latestSession.title || '') : '';
+        return `<div class="discover-row" data-path="${this.escapeHtml(p.realPath)}" data-name="${this.escapeHtml(name)}" data-session-id="${this.escapeHtml(latestSessionId)}" data-session-title="${this.escapeHtml(latestSessionTitle)}">
           <div class="discover-check">
             <input type="checkbox" class="discover-cb" ${p.dirExists ? 'checked' : ''} ${!p.dirExists ? 'disabled' : ''}>
           </div>
@@ -7293,7 +7295,7 @@ class CWMApp {
         const cb = row.querySelector('.discover-cb');
         if (cb && cb.checked) {
           selected.push({
-            name: row.dataset.name,
+            name: row.dataset.sessionTitle || row.dataset.name,
             path: row.dataset.path,
             sessionId: row.dataset.sessionId || '',
           });
@@ -9546,9 +9548,9 @@ class CWMApp {
         const path = p.realPath || '';
         // Match against project name, encoded name, or path
         if (name.toLowerCase().includes(query) || encoded.toLowerCase().includes(query) || path.toLowerCase().includes(query)) return true;
-        // Match against any session ID/name within this project
+        // Match against any session ID, title, or Claude custom-title within this project
         const allSessions = p.sessions || [];
-        return allSessions.some(s => (s.name || '').toLowerCase().includes(query));
+        return allSessions.some(s => (s.name || '').toLowerCase().includes(query) || (s.title || '').toLowerCase().includes(query));
       });
     }
 
@@ -9579,8 +9581,9 @@ class CWMApp {
         if (!projectMatches) {
           sessions = sessions.filter(s => {
             const sName = (s.name || '').toLowerCase();
+            const sClaudeTitle = (s.title || '').toLowerCase();
             const sTitle = (this.getProjectSessionTitle(s.name) || '').toLowerCase();
-            return sName.includes(query) || sTitle.includes(query);
+            return sName.includes(query) || sClaudeTitle.includes(query) || sTitle.includes(query);
           });
         }
       }
@@ -9588,13 +9591,14 @@ class CWMApp {
       // Build session sub-items
       const sessionItems = sessions.map(s => {
         const sessName = s.name || 'unnamed';
+        const claudeTitle = s.title || null;
         const storedTitle = this.getProjectSessionTitle(sessName);
-        const displayName = storedTitle || (sessName.length > 24 ? sessName.substring(0, 24) + '...' : sessName);
+        const displayName = storedTitle || claudeTitle || (sessName.length > 24 ? sessName.substring(0, 24) + '...' : sessName);
         const sessSize = s.size ? this.formatSize(s.size) : '';
         const sessTime = s.modified ? this.relativeTime(s.modified) : '';
-        // Tooltip: show title + session ID so user sees both on hover
-        const tooltip = storedTitle
-          ? `${storedTitle}\n\nSession: ${sessName}`
+        const effectiveTitle = storedTitle || claudeTitle;
+        const tooltip = effectiveTitle
+          ? `${effectiveTitle}\n\nSession: ${sessName}`
           : sessName;
         return `<div class="project-session-item" draggable="true" data-session-name="${this.escapeHtml(sessName)}" data-project-path="${this.escapeHtml(p.realPath || '')}" data-project-encoded="${this.escapeHtml(encoded)}" title="${this.escapeHtml(tooltip)}">
           <span class="project-session-name">${this.escapeHtml(displayName)}</span>

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -7245,7 +7245,7 @@ function extractCustomTitle(jsonlPath) {
     const fd = fs.openSync(jsonlPath, 'r');
     try {
       const size = fs.fstatSync(fd).size;
-      const tailSize = Math.min(16384, size);
+      const tailSize = Math.min(131072, size);
       const buf = Buffer.alloc(tailSize);
       fs.readSync(fd, buf, 0, tailSize, size - tailSize);
       const lines = buf.toString('utf8').split('\n');

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -1646,6 +1646,13 @@ app.get('/api/discover', requireAuth, (req, res) => {
         // skip if can't read
       }
 
+      // Extract the last custom-title from each JSONL file
+      const sessionTitles = {};
+      for (const sf of sessionFiles) {
+        const title = extractCustomTitle(path.join(projectDir, sf.name + '.jsonl'));
+        if (title) sessionTitles[sf.name] = title;
+      }
+
       // Check for CLAUDE.md
       let hasClaudeMd = false;
       try {
@@ -1672,7 +1679,7 @@ app.get('/api/discover', requireAuth, (req, res) => {
         sessionCount: sessionFiles.length,
         totalSize,
         lastActive: sessionFiles.length > 0 ? sessionFiles[0].modified : null,
-        sessions: sessionFiles.map(s => ({ name: s.name, modified: s.modified, size: s.size })),
+        sessions: sessionFiles.map(s => ({ name: s.name, modified: s.modified, size: s.size, title: sessionTitles[s.name] || null })),
       });
     }
 
@@ -1801,48 +1808,34 @@ function greedyFsWalk(root, tokens) {
  */
 function getOriginalPathFromJsonl(projectDir) {
   try {
-    const files = fs.readdirSync(projectDir);
-    // Find the first .jsonl file (skip subdirectories)
-    const jsonlFile = files.find(f => {
+    const jsonlFiles = fs.readdirSync(projectDir).filter(f => {
       if (!f.endsWith('.jsonl')) return false;
-      try {
-        return !fs.statSync(path.join(projectDir, f)).isDirectory();
-      } catch (_) {
-        return false;
-      }
+      try { return !fs.statSync(path.join(projectDir, f)).isDirectory(); } catch (_) { return false; }
     });
-    if (!jsonlFile) return null;
 
-    const jsonlPath = path.join(projectDir, jsonlFile);
-
-    // Only read first 4KB to find cwd field (avoids loading large files)
-    const fd = fs.openSync(jsonlPath, 'r');
-    const buffer = Buffer.alloc(4096);
-    let content;
-    try {
-      const bytesRead = fs.readSync(fd, buffer, 0, 4096, 0);
-      content = buffer.toString('utf-8', 0, bytesRead);
-    } finally {
-      fs.closeSync(fd);
-    }
-
-    // Parse first 3 lines to find cwd field
-    const lines = content.split('\n').slice(0, 3);
-    for (const line of lines) {
-      if (!line.trim()) continue;
+    // Try each file until one yields a cwd — stub sessions may lack it
+    for (const jsonlFile of jsonlFiles) {
       try {
-        const record = JSON.parse(line);
-        if (record.cwd && typeof record.cwd === 'string') {
-          return record.cwd;
+        const fd = fs.openSync(path.join(projectDir, jsonlFile), 'r');
+        let content;
+        try {
+          const buffer = Buffer.alloc(16384);
+          const bytesRead = fs.readSync(fd, buffer, 0, 16384, 0);
+          content = buffer.toString('utf-8', 0, bytesRead);
+        } finally {
+          fs.closeSync(fd);
         }
-      } catch (_) {
-        // Skip invalid JSON lines
-        continue;
-      }
+
+        for (const line of content.split('\n')) {
+          if (!line.includes('"cwd"')) continue;
+          try {
+            const record = JSON.parse(line);
+            if (record.cwd && typeof record.cwd === 'string') return record.cwd;
+          } catch (_) { continue; }
+        }
+      } catch (_) { continue; }
     }
-  } catch (_) {
-    // Silently fail and return null
-  }
+  } catch (_) {}
   return null;
 }
 
@@ -2524,7 +2517,7 @@ app.post('/api/search-conversations', requireAuth, async (req, res) => {
  */
 app.get('/api/keys/anthropic', requireAuth, (req, res) => {
   const store = getStore();
-  const key = (store.getState().settings || {}).anthropicApiKey || '';
+  const key = (store.state.settings || {}).anthropicApiKey || '';
   if (!key) return res.json({ configured: false, masked: null });
   const masked = '...' + key.slice(-8);
   return res.json({ configured: true, masked });
@@ -2560,7 +2553,7 @@ app.post('/api/ai/punctuate', requireAuth, async (req, res) => {
   }
 
   const store = getStore();
-  const apiKey = (store.getState().settings || {}).anthropicApiKey || '';
+  const apiKey = (store.state.settings || {}).anthropicApiKey || '';
   if (!apiKey) {
     return res.status(400).json({ error: 'No Anthropic API key configured' });
   }
@@ -2612,7 +2605,7 @@ app.post('/api/ai/find-session', requireAuth, async (req, res) => {
   }
 
   const store = getStore();
-  const apiKey = (store.getState().settings || {}).anthropicApiKey || '';
+  const apiKey = (store.state.settings || {}).anthropicApiKey || '';
 
   // Gather all metadata
   const workspaces = store.getAllWorkspacesList();
@@ -2631,6 +2624,7 @@ app.post('/api/ai/find-session', requireAuth, async (req, res) => {
         const name = getProjectDisplayName(d.name, realPath);
         let sessionCount = 0;
         let lastActive = null;
+        const sessionTitles = [];
         try {
           const files = fs.readdirSync(projectDir).filter(f => f.endsWith('.jsonl'));
           sessionCount = files.length;
@@ -2639,9 +2633,11 @@ app.post('/api/ai/find-session', requireAuth, async (req, res) => {
               const stat = fs.statSync(path.join(projectDir, f));
               if (!lastActive || stat.mtime > new Date(lastActive)) lastActive = stat.mtime;
             } catch (_) {}
+            const title = extractCustomTitle(path.join(projectDir, f));
+            if (title) sessionTitles.push(title);
           }
         } catch (_) {}
-        return { encodedName: d.name, name, path: realPath, sessionCount, lastActive };
+        return { encodedName: d.name, name, path: realPath, sessionCount, lastActive, sessionTitles };
       });
     } catch (_) {}
   }
@@ -2658,7 +2654,8 @@ app.post('/api/ai/find-session', requireAuth, async (req, res) => {
     })),
     discoveredProjects: discoveredProjects.map(p => ({
       encodedName: p.encodedName, name: p.name, path: p.path,
-      sessionCount: p.sessionCount, lastActive: p.lastActive
+      sessionCount: p.sessionCount, lastActive: p.lastActive,
+      sessionTitles: p.sessionTitles
     }))
   };
 
@@ -2722,9 +2719,9 @@ app.post('/api/ai/find-session', requireAuth, async (req, res) => {
       if (score > 0.2) scored.push({ type: 'session', id: s.id, confidence: score, summary: 'Matched by name, topic, or path' });
     }
     for (const p of discoveredProjects) {
-      const text = `${p.name} ${p.path}`.toLowerCase();
+      const text = `${p.name} ${p.path} ${(p.sessionTitles || []).join(' ')}`.toLowerCase();
       const score = terms.filter(t => text.includes(t)).length / terms.length;
-      if (score > 0.2) scored.push({ type: 'project', id: p.encodedName, confidence: score, summary: 'Matched by project name or path' });
+      if (score > 0.2) scored.push({ type: 'project', id: p.encodedName, confidence: score, summary: 'Matched by project name, path, or session title' });
     }
 
     scored.sort((a, b) => b.confidence - a.confidence);
@@ -7243,6 +7240,30 @@ function getSearchableFiles() {
  * @param {string} sessionId - Fallback UUID
  * @returns {string} A human-readable session name
  */
+function extractCustomTitle(jsonlPath) {
+  try {
+    const fd = fs.openSync(jsonlPath, 'r');
+    try {
+      const size = fs.fstatSync(fd).size;
+      const tailSize = Math.min(16384, size);
+      const buf = Buffer.alloc(tailSize);
+      fs.readSync(fd, buf, 0, tailSize, size - tailSize);
+      const lines = buf.toString('utf8').split('\n');
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].includes('"custom-title"')) {
+          try {
+            const obj = JSON.parse(lines[i]);
+            if (obj.customTitle) return obj.customTitle;
+          } catch (_) {}
+        }
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (_) {}
+  return null;
+}
+
 function extractSessionName(filePath, sessionId) {
   try {
     // Read just the first 10KB to find the first meaningful message
@@ -8054,4 +8075,5 @@ module.exports = {
   startServer,
   getPtyManager,
   structuredError,
+  extractCustomTitle,
 };

--- a/test/run.js
+++ b/test/run.js
@@ -722,6 +722,77 @@ test('AUTH_PASSWORD is not exported from auth module', () => {
 });
 
 // ──────────────────────────────────────────────────────
+// Discovery - Custom Title Extraction
+// ──────────────────────────────────────────────────────
+
+suite('Discovery - extractCustomTitle');
+
+const { extractCustomTitle } = require('../src/web/server');
+const tmpDir = path.join(__dirname, '..', 'state', '_test_jsonl');
+if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
+
+function writeTmpJsonl(name, lines) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, lines.join('\n'), 'utf8');
+  return p;
+}
+
+test('extracts title from a single custom-title entry', () => {
+  const p = writeTmpJsonl('single.jsonl', [
+    '{"type":"permission-mode","permissionMode":"default","sessionId":"aaa"}',
+    '{"type":"custom-title","customTitle":"my-feature","sessionId":"aaa"}',
+    '{"type":"user","message":{"role":"user","content":"hello"}}',
+  ]);
+  assertEqual(extractCustomTitle(p), 'my-feature');
+});
+
+test('returns the last title when renamed', () => {
+  const p = writeTmpJsonl('renamed.jsonl', [
+    '{"type":"custom-title","customTitle":"old-name","sessionId":"bbb"}',
+    '{"type":"user","message":{"role":"user","content":"do stuff"}}',
+    '{"type":"custom-title","customTitle":"new-name","sessionId":"bbb"}',
+  ]);
+  assertEqual(extractCustomTitle(p), 'new-name');
+});
+
+test('returns null when no custom-title exists', () => {
+  const p = writeTmpJsonl('notitle.jsonl', [
+    '{"type":"permission-mode","permissionMode":"default","sessionId":"ccc"}',
+    '{"type":"user","message":{"role":"user","content":"hello"}}',
+  ]);
+  assertEqual(extractCustomTitle(p), null);
+});
+
+test('returns null for malformed JSON on custom-title line', () => {
+  const p = writeTmpJsonl('malformed.jsonl', [
+    '{"type":"permission-mode","sessionId":"ddd"}',
+    '{"type":"custom-title" BROKEN JSON',
+  ]);
+  assertEqual(extractCustomTitle(p), null);
+});
+
+test('returns null for nonexistent file', () => {
+  assertEqual(extractCustomTitle(path.join(tmpDir, 'nonexistent.jsonl')), null);
+});
+
+test('finds title in tail of large file', () => {
+  // Pad with 20KB of filler lines so the title is only in the last 16KB
+  const filler = [];
+  for (let i = 0; i < 200; i++) {
+    filler.push(`{"type":"user","message":{"role":"user","content":"${'x'.repeat(100)}"}}`);
+  }
+  filler.push('{"type":"custom-title","customTitle":"deep-title","sessionId":"eee"}');
+  const p = writeTmpJsonl('large.jsonl', filler);
+  assertEqual(extractCustomTitle(p), 'deep-title');
+});
+
+// Clean up temp files
+try {
+  for (const f of fs.readdirSync(tmpDir)) fs.unlinkSync(path.join(tmpDir, f));
+  fs.rmdirSync(tmpDir);
+} catch (_) {}
+
+// ──────────────────────────────────────────────────────
 // Results
 
 console.log('\n  ' + '─'.repeat(42));


### PR DESCRIPTION
## Summary

- **Session titles**: The Discovered sidebar now shows Claude's session names (e.g. "fix-auth-issues") instead of truncated UUIDs. Extracted from `custom-title` entries in JSONL files via a positioned tail read (last 16KB) with reverse scan — cross-platform, O(1) memory.
- **cwd extraction fix (buffer)**: Increased head read buffer from 4KB to 16KB with a string pre-filter. Hook attachment entries on line 2 can exceed 4KB, truncating JSON.parse and causing the path lookup to fail silently.
- **cwd extraction fix (stub sessions)**: Now tries multiple JSONL files instead of only the first alphabetical one. Stub sessions (1-line permission-mode only) lack a `cwd` field, which caused projects to show as greyed-out/missing even when the directory exists.
- **Find a Conversation**: Keyword search and AI metadata now include session titles, so queries match against session names (not just project paths).
- **store.getState() fix**: Three call sites used `store.getState()` which doesn't exist — the Store exposes `store.state` as a getter property. This broke the API key check, AI title generation, and Find a Conversation.

## How it works

Claude stores session titles inline in JSONL as `{"type":"custom-title","customTitle":"..."}` entries. The `/api/discover` endpoint now calls `extractCustomTitle(path)` per session file — reads the last 16KB via positioned `fs.readSync`, splits and scans in reverse. First match wins (last entry = current title after renames). The 30-second discovery cache prevents repeated I/O.

The frontend uses the server-provided title as the primary display, with localStorage overrides for user renames. Titles are also searchable in the sidebar filter, and import uses the session title as the default name when linking.

## Future work

The codebase has 6+ functions that read JSONL files with similar head/tail buffer patterns. A shared utility module (`readJsonlHead`, `readJsonlTail`, `scanJsonlForField`) would reduce duplication and make the buffer/parsing logic testable in one place.

## Test plan

- [ ] Discovered panel shows session titles instead of UUIDs for sessions that have them
- [ ] Sessions without a custom-title still show truncated UUID
- [ ] Renamed sessions show the latest title (last `custom-title` entry wins)
- [ ] Typing a session name in the sidebar filter matches against titles
- [ ] Importing a session uses the title as the default name
- [ ] Projects that previously showed as grey/missing now resolve correctly
- [ ] Find a Conversation returns results when searching by session title (e.g. "fix")
- [ ] `npm test` passes (58 tests including 6 new ones for extractCustomTitle)