### PR TITLE
feat: enable Progressive Web App (PWA) support

### DIFF
--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -9,6 +9,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
   <link rel="icon" type="image/png" sizes="192x192" href="favicon-192.png">
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
+  <link rel="manifest" href="/manifest.webmanifest">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,500&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -1688,5 +1689,10 @@
   <script src="vendor/xterm-addon-web-links/xterm-addon-web-links.min.js"></script>
   <script src="terminal.js"></script>
   <script src="app.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('/sw.js').catch(() => {}));
+    }
+  </script>
 </body>
 </html>

--- a/src/web/public/manifest.webmanifest
+++ b/src/web/public/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "myrlin's workbook",
+  "short_name": "Workbook",
+  "description": "Manage Claude Code sessions",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#1e1e2e",
+  "theme_color": "#1e1e2e",
+  "icons": [
+    { "src": "/logo.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+    { "src": "/logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
+  ]
+}

--- a/src/web/public/sw.js
+++ b/src/web/public/sw.js
@@ -1,0 +1,3 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));
+self.addEventListener('fetch', () => {});


### PR DESCRIPTION
This PR introduces PWA support. It adds a manifest.webmanifest, a basic service worker (sw.js), and wires them into index.html. This allows users to "install" the app locally on desktop and mobile devices for a native-like, full-screen experience. 
Note: Https is required e.g. via a reverse proxy