### PR TITLE
feat: optional toggle to disable mobile virtual keyboard

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -240,6 +240,7 @@ class CWMApp {
       logoutBtn: document.getElementById('logout-btn'),
       themeToggleBtn: document.getElementById('theme-toggle-btn'),
       themeDropdown: document.getElementById('theme-dropdown'),
+      vkbToggleBtn: document.getElementById('vkb-toggle-btn'),
       scaleDownBtn: document.getElementById('scale-down-btn'),
       scaleUpBtn: document.getElementById('scale-up-btn'),
 
@@ -557,6 +558,34 @@ class CWMApp {
       document.addEventListener('click', () => {
         if (this.els.themeDropdown) this.els.themeDropdown.hidden = true;
       });
+    }
+
+    // Virtual keyboard toggle. inputmode="none" is a no-op on devices without
+    // a soft keyboard, so we apply it unconditionally instead of trying to
+    // detect "is mobile" (which is unreliable across browsers).
+    this._vkbDisabled = localStorage.getItem('cwm_vkb_disabled') === '1';
+    this._applyVkbState();
+    if (this.els.vkbToggleBtn) {
+      this.els.vkbToggleBtn.addEventListener('click', () => {
+        this._vkbDisabled = !this._vkbDisabled;
+        localStorage.setItem('cwm_vkb_disabled', this._vkbDisabled ? '1' : '0');
+        this._applyVkbState();
+      });
+      // Watch for newly-created xterm helper textareas and apply state to them.
+      const obs = new MutationObserver((muts) => {
+        if (!this._vkbDisabled) return;
+        for (const m of muts) {
+          for (const n of m.addedNodes) {
+            if (n.nodeType !== 1) continue;
+            if (n.matches && n.matches('.xterm-helper-textarea')) {
+              n.setAttribute('inputmode', 'none');
+            } else if (n.querySelectorAll) {
+              n.querySelectorAll('.xterm-helper-textarea').forEach(t => t.setAttribute('inputmode', 'none'));
+            }
+          }
+        }
+      });
+      obs.observe(document.body, { childList: true, subtree: true });
     }
 
     // Sidebar toggle (mobile)
@@ -3530,6 +3559,22 @@ class CWMApp {
       if (tp && tp.term) {
         tp.term.options.theme = TerminalPane.getCurrentTheme();
       }
+    });
+  }
+
+  _applyVkbState() {
+    const btn = this.els && this.els.vkbToggleBtn;
+    const active = !!this._vkbDisabled;
+    if (btn) {
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      btn.title = active
+        ? 'On-screen keyboard disabled (click to enable)'
+        : 'Disable on-screen keyboard (hardware keyboard only)';
+    }
+    document.querySelectorAll('.xterm-helper-textarea').forEach(t => {
+      if (active) t.setAttribute('inputmode', 'none');
+      else t.removeAttribute('inputmode');
     });
   }
 

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -182,6 +182,13 @@
             <button class="theme-option" data-theme="gruvbox-light"><span class="theme-swatch" style="background:#fbf1c7;border:1px solid #d5c4a1"></span>Gruvbox Light</button>
           </div>
         </div>
+        <button class="btn btn-ghost btn-icon btn-sm vkb-toggle-btn" id="vkb-toggle-btn" title="Disable on-screen keyboard (hardware keyboard only)" aria-pressed="false">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="1.5" y="4" width="13" height="8" rx="1.5"/>
+            <path d="M4 7h.01M6 7h.01M8 7h.01M10 7h.01M12 7h.01M5 9.5h6"/>
+            <line class="vkb-slash" x1="2.5" y1="13.5" x2="13.5" y2="2.5" stroke-width="1.6"/>
+          </svg>
+        </button>
         <button class="btn btn-ghost btn-icon btn-sm" id="pair-mobile-btn" title="Pair Mobile Device">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <rect x="4" y="1" width="8" height="14" rx="1.5"/>

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1364,6 +1364,10 @@ textarea.input {
   color: var(--mauve) !important;
 }
 
+.vkb-toggle-btn .vkb-slash { display: none; }
+.vkb-toggle-btn.active { color: var(--mauve) !important; }
+.vkb-toggle-btn.active .vkb-slash { display: inline; }
+
 
 /* ─── Main Content ──────────────────────────────────────────── */
 


### PR DESCRIPTION
This PR adds a UI toggle button that conditionally applies inputmode="none" to the hidden xterm.js textareas. This is highly useful for users on touch devices (tablets/phones) who use hardware keyboards and want to prevent the on-screen software keyboard from continuously popping up.

<img width="166" height="32" alt="image" src="https://github.com/user-attachments/assets/5bd828bc-1c86-48e9-955e-14274451ade2" />
