### PR TITLE
feat: scheduled messages — fire commands into a session on a delay or interval

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1885,6 +1885,7 @@ class CWMApp {
     this.connectSSE();
     this.startConflictChecks();
     this.checkForUpdates();
+    this.startSchedulePolling();
   }
 
   async init() {
@@ -8945,6 +8946,8 @@ class CWMApp {
     // Fetch all session costs in a single batch request (non-blocking)
     this._fetchSessionCostsAsync();
 
+    // Re-apply schedule indicators since renderWorkspaces() rewrote the tree.
+    if (this._scheduleCounts) this.applyScheduleIndicators();
 
     this.els.workspaceCount.textContent = `${workspaces.length} project${workspaces.length !== 1 ? 's' : ''}`;
   }
@@ -9175,6 +9178,105 @@ class CWMApp {
     this._renderContextItems(group.name, items, x, y);
   }
 
+  /**
+   * Poll /api/schedules/summary every 10 s and apply active-schedule
+   * indicators to pane badges, pane titles, and sidebar session items.
+   * Refreshes on the same cadence as the existing per-pane git poller.
+   */
+  startSchedulePolling() {
+    if (this._scheduleSummaryInterval) return;
+    this._scheduleCounts = {};
+    this.refreshScheduleIndicators();
+    this._scheduleSummaryInterval = setInterval(() => this.refreshScheduleIndicators(), 10_000);
+  }
+
+  async refreshScheduleIndicators() {
+    if (!this.state || !this.state.token) return;
+    try {
+      const r = await fetch('/api/schedules/summary', {
+        headers: { Authorization: 'Bearer ' + this.state.token },
+        credentials: 'same-origin',
+      });
+      if (!r.ok) return;
+      const data = await r.json();
+      this._scheduleCounts = (data && data.counts) || {};
+      this.applyScheduleIndicators();
+    } catch (_) { /* network blip — try again next tick */ }
+  }
+
+  applyScheduleIndicators() {
+    const counts = this._scheduleCounts || {};
+
+    // Pane badge + title-bar clock for each terminal pane
+    for (let i = 0; i < 6; i++) {
+      const paneEl = document.getElementById(`term-pane-${i}`);
+      if (!paneEl) continue;
+      const tp = this.terminalPanes[i];
+      const sid = tp ? tp.sessionId : null;
+      const n = sid ? (counts[sid] || 0) : 0;
+
+      // Floating clock button badge (number)
+      const btn = paneEl.querySelector('.terminal-pane-schedule');
+      if (btn) {
+        const badge = btn.querySelector('.pane-schedule-count');
+        if (badge) {
+          badge.textContent = n > 0 ? String(n) : '';
+          badge.hidden = !(n > 0);
+        }
+      }
+
+      // Inline clock icon inside the title span (right after the text) so it
+      // sits flush against the title without being pushed by header flex gap.
+      const titleEl = paneEl.querySelector('.terminal-pane-title');
+      if (titleEl) {
+        let titleClock = titleEl.querySelector('.pane-title-clock');
+        if (n > 0) {
+          if (!titleClock) {
+            titleClock = document.createElement('span');
+            titleClock.className = 'pane-title-clock';
+            titleClock.title = 'Has scheduled messages';
+            titleClock.innerHTML = '<svg width="13" height="13"><use href="#icon-clock"/></svg>';
+            titleEl.appendChild(titleClock);
+          }
+        } else if (titleClock) {
+          titleClock.remove();
+        }
+      }
+    }
+
+    // Sidebar items live in two lists with different DOM shapes:
+    //   .session-item[data-id]            (all-sessions list, .session-name child)
+    //   .ws-session-item[data-session-id] (per-workspace tree, .ws-session-name child)
+    // Names use ellipsis overflow, so the icon gets prepended (not appended).
+    const sidebarTargets = [
+      { itemSel: '.session-item[data-id]',           idAttr: 'id',        nameSel: '.session-name' },
+      { itemSel: '.ws-session-item[data-session-id]', idAttr: 'sessionId', nameSel: '.ws-session-name' },
+    ];
+    for (const { itemSel, idAttr, nameSel } of sidebarTargets) {
+      document.querySelectorAll(itemSel).forEach(item => {
+        const sid = item.dataset[idAttr];
+        if (!sid) return;
+        const n = counts[sid] || 0;
+        const nameEl = item.querySelector(nameSel);
+        if (!nameEl) return;
+        let icon = nameEl.querySelector('.session-schedule-clock');
+        if (n > 0) {
+          if (!icon) {
+            icon = document.createElement('span');
+            icon.className = 'session-schedule-clock';
+            icon.title = `${n} scheduled message${n === 1 ? '' : 's'}`;
+            icon.innerHTML = '<svg width="11" height="11"><use href="#icon-clock"/></svg>';
+            nameEl.prepend(icon);
+          } else {
+            icon.title = `${n} scheduled message${n === 1 ? '' : 's'}`;
+          }
+        } else if (icon) {
+          icon.remove();
+        }
+      });
+    }
+  }
+
   renderSessions() {
     const list = this.els.sessionList;
     const sessions = this.state.sessions.filter(s => this.state.showHidden || !this.state.hiddenSessions.has(s.id));
@@ -9216,6 +9318,9 @@ class CWMApp {
         </div>`;
     }).join('');
 
+
+    // Re-apply schedule indicators since renderSessions() rewrites the list
+    if (this._scheduleCounts) this.applyScheduleIndicators();
 
     // Async: patch in git branch badges
     const sessionItems = list.querySelectorAll('.session-item[data-id]');
@@ -10168,6 +10273,17 @@ class CWMApp {
           });
         }
 
+        // Schedule clock button — opens the schedule popover for this pane's session
+        const scheduleBtn = pane.querySelector('.terminal-pane-schedule');
+        if (scheduleBtn) {
+          scheduleBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const tp = this.terminalPanes[slotIdx];
+            if (!tp || !tp.sessionId) return;
+            if (window.SchedulePopover) window.SchedulePopover.toggle(scheduleBtn, tp.sessionId);
+          });
+        }
+
         // Pane view back button — restores terminal after a non-terminal view (E003)
         const backBtn = pane.querySelector('.pane-view-back');
         if (backBtn) {
@@ -10303,6 +10419,13 @@ class CWMApp {
     if (closeBtn) closeBtn.hidden = false;
     const uploadBtn2 = paneEl.querySelector('.terminal-pane-upload');
     if (uploadBtn2) uploadBtn2.hidden = false;
+    const scheduleBtn2 = paneEl.querySelector('.terminal-pane-schedule');
+    if (scheduleBtn2) {
+      scheduleBtn2.hidden = false;
+      // The 10 s schedule poller drives the badge; kick off an immediate
+      // refresh so a freshly-attached pane reflects current state right away.
+      if (this.refreshScheduleIndicators) this.refreshScheduleIndicators();
+    }
     // Show mic button if SpeechRecognition is supported
     const micBtn2 = paneEl.querySelector('.terminal-pane-mic');
     if (micBtn2 && this._speechRecognitionAvailable) micBtn2.hidden = false;
@@ -10329,11 +10452,17 @@ class CWMApp {
       this.terminalPanes[idx] = null;
       const deadPane = document.getElementById(`term-pane-${idx}`);
       if (deadPane) {
+        // Close the schedule popover if it was anchored to this pane.
+        if (window.SchedulePopover && window.SchedulePopover.anchor && deadPane.contains(window.SchedulePopover.anchor)) {
+          window.SchedulePopover.close();
+        }
         deadPane.classList.add('terminal-pane-empty');
         const header = deadPane.querySelector('.terminal-pane-title');
         if (header) header.textContent = 'Drop a session here';
         const closeBtn2 = deadPane.querySelector('.terminal-pane-close');
         if (closeBtn2) closeBtn2.hidden = true;
+        const scheduleBtn3 = deadPane.querySelector('.terminal-pane-schedule');
+        if (scheduleBtn3) scheduleBtn3.hidden = true;
       }
       this.updateTerminalGridLayout();
     };
@@ -10770,6 +10899,13 @@ class CWMApp {
   }
 
   closeTerminalPane(slotIdx) {
+    // If our schedule popover is anchored on this pane's clock, close it.
+    if (window.SchedulePopover && window.SchedulePopover.anchor) {
+      const paneElForPopover = document.getElementById(`term-pane-${slotIdx}`);
+      if (paneElForPopover && paneElForPopover.contains(window.SchedulePopover.anchor)) {
+        window.SchedulePopover.close();
+      }
+    }
     if (this._paneRefreshTimers[slotIdx]) {
       clearInterval(this._paneRefreshTimers[slotIdx]);
       delete this._paneRefreshTimers[slotIdx];
@@ -10796,6 +10932,12 @@ class CWMApp {
     if (closeBtn) closeBtn.hidden = true;
     const uploadBtn3 = paneEl.querySelector('.terminal-pane-upload');
     if (uploadBtn3) uploadBtn3.hidden = true;
+    const scheduleBtn3 = paneEl.querySelector('.terminal-pane-schedule');
+    if (scheduleBtn3) {
+      scheduleBtn3.hidden = true;
+      const badge = scheduleBtn3.querySelector('.pane-schedule-count');
+      if (badge) { badge.textContent = ''; badge.hidden = true; }
+    }
     // Collapse any active expansion before closing
     this._collapseExpandPane(slotIdx);
     const expandBtn3 = paneEl.querySelector('.terminal-pane-expand');
@@ -11110,6 +11252,7 @@ class CWMApp {
       const titleEl = paneEl ? paneEl.querySelector('.terminal-pane-title') : null;
       const closeBtn = paneEl ? paneEl.querySelector('.terminal-pane-close') : null;
       const uploadBtnEl = paneEl ? paneEl.querySelector('.terminal-pane-upload') : null;
+      const scheduleBtnEl = paneEl ? paneEl.querySelector('.terminal-pane-schedule') : null;
       const micBtnEl = paneEl ? paneEl.querySelector('.terminal-pane-mic') : null;
       if (!paneEl) return;
 
@@ -11120,6 +11263,7 @@ class CWMApp {
         if (titleEl) titleEl.textContent = tp.sessionName || tp.sessionId;
         if (closeBtn) closeBtn.hidden = false;
         if (uploadBtnEl) uploadBtnEl.hidden = false;
+        if (scheduleBtnEl) scheduleBtnEl.hidden = false;
         if (micBtnEl && this._speechRecognitionAvailable) micBtnEl.hidden = false;
         // Move the xterm element into the new container
         if (container && tp.term) {
@@ -11136,6 +11280,11 @@ class CWMApp {
         if (titleEl) titleEl.textContent = 'Drop a session here';
         if (closeBtn) closeBtn.hidden = true;
         if (uploadBtnEl) uploadBtnEl.hidden = true;
+        if (scheduleBtnEl) {
+          scheduleBtnEl.hidden = true;
+          const badge = scheduleBtnEl.querySelector('.pane-schedule-count');
+          if (badge) { badge.textContent = ''; badge.hidden = true; }
+        }
         if (micBtnEl) { micBtnEl.hidden = true; micBtnEl.classList.remove('mic-active'); }
         if (container) container.innerHTML = '';
       }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -28,6 +28,15 @@
   </script>
 </head>
 <body>
+  <!-- SVG icon sprite. Reference with <svg class="icon-clock"><use href="#icon-clock"/></svg> -->
+  <svg width="0" height="0" style="position:absolute" aria-hidden="true">
+    <symbol id="icon-clock" viewBox="0 0 16 16">
+      <g fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <circle cx="8" cy="8" r="6.5"/>
+        <polyline points="8 4 8 8 10.5 9.5"/>
+      </g>
+    </symbol>
+  </svg>
 
   <!-- ═══════════════════════════════════════════ -->
   <!-- LOGIN SCREEN                                -->
@@ -578,6 +587,10 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
+            </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
               <button class="mobile-send-btn">Send</button>
@@ -627,6 +640,10 @@
             <div class="pane-view-container" id="pane-view-1" hidden></div>
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
+            </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
             </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
@@ -678,6 +695,10 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
+            </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
               <button class="mobile-send-btn">Send</button>
@@ -727,6 +748,10 @@
             <div class="pane-view-container" id="pane-view-3" hidden></div>
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
+            </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
             </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
@@ -778,6 +803,10 @@
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
             </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
+            </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
               <button class="mobile-send-btn">Send</button>
@@ -827,6 +856,10 @@
             <div class="pane-view-container" id="pane-view-5" hidden></div>
             <button class="terminal-pane-upload" hidden title="Upload image to Claude">
               <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 10v3.5a1 1 0 01-1 1h-11a1 1 0 01-1-1V10"/><polyline points="4.5 5.5 8 2 11.5 5.5"/><line x1="8" y1="2" x2="8" y2="10.5"/></svg>
+            </button>
+            <button class="terminal-pane-schedule" hidden title="Scheduled messages">
+              <svg width="14" height="14"><use href="#icon-clock"/></svg>
+              <span class="pane-schedule-count" hidden>0</span>
             </button>
             <div class="terminal-mobile-input-row">
               <input type="text" class="mobile-type-input" placeholder="Type here..." enterkeyhint="send" autocomplete="off" />
@@ -1717,6 +1750,7 @@
   <script src="vendor/xterm-addon-web-links/xterm-addon-web-links.min.js"></script>
   <script src="terminal.js"></script>
   <script src="app.js"></script>
+  <script src="schedules.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => navigator.serviceWorker.register('/sw.js').catch(() => {}));

--- a/src/web/public/schedules.js
+++ b/src/web/public/schedules.js
@@ -1,0 +1,427 @@
+/**
+ * Schedule popover — anchors under a pane's clock button and shows a small
+ * Active / History form + list. One shared instance, repositioned on each open.
+ *
+ * Usage: SchedulePopover.toggle(anchorEl, sessionId)
+ *        SchedulePopover.close()
+ */
+(function () {
+  'use strict';
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, ch => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+  }
+
+  const SchedulePopover = {
+    el: null,                // root popover element
+    activeTab: 'active',     // 'active' | 'history'
+    sessionId: null,
+    anchor: null,
+    _docHandlers: null,
+    _tickerHandle: null,
+    _pollHandle: null,
+    _latestActive: null,
+
+    toggle(anchorEl, sessionId) {
+      if (this.el && this.anchor === anchorEl) {
+        this.close();
+        return;
+      }
+      this.open(anchorEl, sessionId);
+    },
+
+    open(anchorEl, sessionId) {
+      // If already open on a different anchor, close first.
+      if (this.el) this.close();
+      this.sessionId = sessionId;
+      this.anchor = anchorEl;
+      this._build();
+      this._setTab('active');
+      this._reposition();
+      this._render();
+      this._installDocHandlers();
+      this._startPoller();
+    },
+
+    close() {
+      if (!this.el) return;
+      if (this._tickerHandle) { clearInterval(this._tickerHandle); this._tickerHandle = null; }
+      this._stopPoller();
+      this.el.remove();
+      this.el = null;
+      this.sessionId = null;
+      this.anchor = null;
+      this._removeDocHandlers();
+    },
+
+    _build() {
+      const root = document.createElement('div');
+      root.className = 'schedule-popover';
+      root.innerHTML = `
+        <div class="schedule-popover-tabs">
+          <button class="schedule-popover-tab active" data-tab="active">Active</button>
+          <button class="schedule-popover-tab" data-tab="history">History</button>
+        </div>
+        <div class="schedule-popover-body" data-body></div>
+      `;
+      root.addEventListener('click', (e) => {
+        const tabBtn = e.target.closest('.schedule-popover-tab');
+        if (tabBtn) {
+          this._setTab(tabBtn.dataset.tab);
+          this._render();
+        }
+      });
+      // Stop clicks inside from bubbling to the document outside-handler
+      root.addEventListener('mousedown', (e) => e.stopPropagation());
+      document.body.appendChild(root);
+      this.el = root;
+    },
+
+    _setTab(tab) {
+      this.activeTab = tab;
+      this.el.querySelectorAll('.schedule-popover-tab').forEach(b => {
+        b.classList.toggle('active', b.dataset.tab === tab);
+      });
+    },
+
+    _reposition() {
+      if (!this.el || !this.anchor) return;
+      const r = this.anchor.getBoundingClientRect();
+      const margin = 8;
+      const popW = this.el.offsetWidth || 360;
+      const popH = this.el.offsetHeight || 320;
+      // The schedule button floats at the bottom-right of the pane, so the
+      // popover opens above-and-left of it (right edge aligned to button's
+      // right edge, bottom edge above the button with a margin).
+      let left = r.right - popW;
+      let top = r.top - popH - margin;
+      // If there isn't enough room above, fall back to opening below.
+      if (top < 8) top = r.bottom + margin;
+      // Clamp inside viewport horizontally.
+      if (left < 8) left = 8;
+      const maxLeft = window.innerWidth - popW - 8;
+      if (left > maxLeft) left = Math.max(8, maxLeft);
+      this.el.style.left = `${left}px`;
+      this.el.style.top = `${top}px`;
+    },
+
+    _render() {
+      const body = this.el.querySelector('[data-body]');
+      if (this.activeTab === 'active') {
+        body.innerHTML = this._renderActive();
+        this._wireFormHandlers(body);
+        this._refreshList();
+      } else {
+        body.innerHTML = `<div class="schedule-list" data-history></div>`;
+        this._refreshHistory();
+      }
+      // Reposition after content drops in — the popover height changes,
+      // and we anchor the bottom above the button.
+      this._reposition();
+    },
+
+    _renderActive() {
+      // Pre-fill the date with today's local date; leave time empty so the
+      // user has to pick it deliberately (datetime-local can't hold a date-only value).
+      const now = new Date();
+      const todayLocal = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+      return `
+        <form class="schedule-form" data-form>
+          <label>Message
+            <input type="text" name="command" maxlength="2048" placeholder="Message.." required />
+          </label>
+          <label>When</label>
+          <div class="row">
+            <label><input type="radio" name="when" value="in" checked /> in</label>
+            <input class="num" type="number" name="delayN" min="1" value="5" />
+            <select class="unit" name="delayUnit">
+              <option value="s">sec</option>
+              <option value="m" selected>min</option>
+              <option value="h">hr</option>
+              <option value="d">day</option>
+            </select>
+          </div>
+          <div class="row">
+            <label><input type="radio" name="when" value="at" /> at</label>
+            <input class="date" type="date" name="fireDate" value="${todayLocal}" />
+            <input class="time" type="time" name="fireTime" />
+          </div>
+          <label class="row">
+            <input type="checkbox" name="repeat" />
+            <span>Repeat (use the delay above as the interval)</span>
+          </label>
+          <div class="form-error" data-form-error style="color: var(--red); font-size: 11px; min-height: 14px;"></div>
+          <div class="actions">
+            <button type="button" data-cancel class="btn btn-ghost btn-sm">Cancel</button>
+            <button type="submit" data-save class="btn btn-primary btn-sm">Save</button>
+          </div>
+        </form>
+        <div class="schedule-list" data-list></div>
+      `;
+    },
+
+    _wireFormHandlers(body) {
+      const form = body.querySelector('[data-form]');
+      const errorEl = body.querySelector('[data-form-error]');
+      const repeatBox = form.querySelector('input[name="repeat"]');
+      // Auto-focus the message field so the user can start typing immediately.
+      const msgInput = form.querySelector('input[name="command"]');
+      if (msgInput) setTimeout(() => msgInput.focus(), 0);
+      const inMode = () => form.querySelector('input[name="when"]:checked').value === 'in';
+      const updateRepeatEnable = () => {
+        repeatBox.disabled = !inMode();
+        if (!inMode()) repeatBox.checked = false;
+      };
+      form.querySelectorAll('input[name="when"]').forEach(r => r.addEventListener('change', updateRepeatEnable));
+      updateRepeatEnable();
+
+      form.querySelector('[data-cancel]').addEventListener('click', () => {
+        form.reset();
+        errorEl.textContent = '';
+        updateRepeatEnable();
+      });
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        errorEl.textContent = '';
+        const fd = new FormData(form);
+        const command = (fd.get('command') || '').toString();
+        const when = fd.get('when');
+        const repeat = !!fd.get('repeat');
+        let payload;
+        if (when === 'in') {
+          const n = Number(fd.get('delayN'));
+          const unit = fd.get('delayUnit');
+          const ms = SchedulePopover._unitToMs(n, unit);
+          if (!Number.isFinite(ms) || ms < 1000) { errorEl.textContent = 'Delay must be at least 1 second'; return; }
+          payload = { command, kind: repeat ? 'recurring' : 'once', delayMs: ms };
+        } else {
+          const date = (fd.get('fireDate') || '').toString();
+          const time = (fd.get('fireTime') || '').toString();
+          if (!date) { errorEl.textContent = 'Pick a date'; return; }
+          if (!time) { errorEl.textContent = 'Pick a time'; return; }
+          const fireAt = new Date(`${date}T${time}`).getTime();
+          if (!Number.isFinite(fireAt)) { errorEl.textContent = 'Invalid date/time'; return; }
+          payload = { command, kind: 'once', fireAt };
+        }
+        try {
+          const res = await SchedulePopover._fetch('POST', '', payload);
+          if (!res.ok) {
+            errorEl.textContent = (res.json && res.json.error) || `Save failed (${res.status})`;
+            return;
+          }
+          form.reset();
+          updateRepeatEnable();
+          await this._refreshList();
+          this._refreshBadge();
+          if (window.cwm && window.cwm.refreshScheduleIndicators) window.cwm.refreshScheduleIndicators();
+        } catch (err) {
+          errorEl.textContent = err.message || 'Network error';
+        }
+      });
+    },
+
+    async _refreshList() {
+      const listEl = this.el && this.el.querySelector('[data-list]');
+      if (!listEl) return;
+      const res = await SchedulePopover._fetch('GET', '');
+      if (!res.ok) {
+        listEl.innerHTML = `<div class="schedule-empty">Failed to load (${res.status})</div>`;
+        this._reposition();
+        return;
+      }
+      const active = (res.json && res.json.active) || [];
+      this._latestActive = active;
+      this._renderList(listEl, active);
+      this._refreshBadge(active.length);
+      this._restartTicker();
+      this._reposition();
+    },
+
+    _renderList(listEl, active) {
+      if (active.length === 0) {
+        listEl.innerHTML = `<div class="schedule-empty">No active schedules</div>`;
+        return;
+      }
+      const rows = active.map(s => `
+        <div class="schedule-row" data-id="${s.id}">
+          <span class="glyph">${s.kind === 'once' ? '⏱' : '⟳'}</span>
+          <span class="label">${escapeHtml(s.command)}</span>
+          <span class="when" data-when data-next="${s.nextFireAt}" data-kind="${s.kind}" data-delay="${s.delayMs || 0}"></span>
+          <button class="trash" title="Delete">🗑</button>
+        </div>
+      `).join('');
+      listEl.innerHTML = `<div class="schedule-list-header">Active (${active.length})</div>${rows}`;
+      listEl.querySelectorAll('.trash').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          const row = btn.closest('.schedule-row');
+          if (!row) return;
+          if (!window.confirm('Delete this schedule?')) return;
+          const id = row.dataset.id;
+          await SchedulePopover._fetch('DELETE', '/' + id);
+          await this._refreshList();
+          if (window.cwm && window.cwm.refreshScheduleIndicators) window.cwm.refreshScheduleIndicators();
+        });
+      });
+      this._tickRelativeLabels(listEl);
+    },
+
+    _tickRelativeLabels(listEl) {
+      const now = Date.now();
+      listEl.querySelectorAll('[data-when]').forEach(el => {
+        const next = Number(el.dataset.next);
+        const kind = el.dataset.kind;
+        const delay = Number(el.dataset.delay);
+        if (kind === 'recurring') {
+          el.textContent = '· every ' + SchedulePopover._fmtDuration(delay);
+        } else {
+          const ms = next - now;
+          el.textContent = '· in ' + SchedulePopover._fmtDuration(ms);
+        }
+      });
+    },
+
+    _restartTicker() {
+      if (this._tickerHandle) clearInterval(this._tickerHandle);
+      this._tickerHandle = setInterval(() => {
+        const listEl = this.el && this.el.querySelector('[data-list]');
+        if (!listEl) return;
+        this._tickRelativeLabels(listEl);
+      }, 1000);
+    },
+
+    _refreshBadge(count) {
+      if (!this.anchor) return;
+      const badge = this.anchor.querySelector('.pane-schedule-count');
+      if (!badge) return;
+      const n = Number.isFinite(count) ? count : (this._latestActive ? this._latestActive.length : 0);
+      if (n > 0) {
+        badge.textContent = String(n);
+        badge.hidden = false;
+      } else {
+        badge.textContent = '';
+        badge.hidden = true;
+      }
+    },
+
+    async _refreshHistory() {
+      const histEl = this.el && this.el.querySelector('[data-history]');
+      if (!histEl) return;
+      const res = await SchedulePopover._fetch('GET', '');
+      if (!res.ok) {
+        histEl.innerHTML = `<div class="schedule-empty">Failed to load (${res.status})</div>`;
+        this._reposition();
+        return;
+      }
+      const rows = (res.json && res.json.history) || [];
+      if (rows.length === 0) {
+        histEl.innerHTML = `<div class="schedule-empty">No history yet</div>`;
+        this._reposition();
+        return;
+      }
+      const now = Date.now();
+      const html = rows.map(r => {
+        const ago = SchedulePopover._fmtAgo(now - r.firedAt);
+        if (r.status === 'success') {
+          return `<div class="schedule-row">
+            <span class="glyph" style="color:var(--green)">✓</span>
+            <span class="label">${escapeHtml(r.command)}</span>
+            <span class="when">· ${ago}</span>
+          </div>`;
+        }
+        const reason =
+          r.skipReason === 'session-not-running' ? 'session not running'
+          : r.skipReason === 'missed-while-down' ? 'missed while server down'
+          : 'skipped';
+        const count = r.skipCount > 1 ? `Skipped ${r.skipCount} — ${reason}` : `Skipped — ${reason}`;
+        return `<div class="schedule-row">
+          <span class="glyph" style="color:var(--peach)">⊘</span>
+          <span class="label" style="color:var(--subtext0)">${escapeHtml(count)}</span>
+          <span class="when">· ${ago}</span>
+        </div>`;
+      }).join('');
+      histEl.innerHTML = html;
+      this._reposition();
+    },
+
+    _fmtAgo(ms) {
+      if (ms < 60_000) return Math.max(1, Math.floor(ms / 1000)) + 's ago';
+      if (ms < 3_600_000) return Math.floor(ms / 60_000) + 'm ago';
+      if (ms < 86_400_000) return Math.floor(ms / 3_600_000) + 'h ago';
+      return Math.floor(ms / 86_400_000) + 'd ago';
+    },
+
+    _startPoller() {
+      this._stopPoller();
+      this._pollHandle = setInterval(() => {
+        if (!this.el) return;
+        if (this.activeTab === 'active') this._refreshList();
+        else this._refreshHistory();
+      }, 5000);
+    },
+
+    _stopPoller() {
+      if (this._pollHandle) { clearInterval(this._pollHandle); this._pollHandle = null; }
+    },
+
+    _installDocHandlers() {
+      const onKey = (e) => { if (e.key === 'Escape') this.close(); };
+      const onMouse = (e) => {
+        if (!this.el) return;
+        if (this.el.contains(e.target)) return;
+        if (this.anchor && this.anchor.contains(e.target)) return;
+        this.close();
+      };
+      const onResize = () => this._reposition();
+      document.addEventListener('keydown', onKey);
+      document.addEventListener('mousedown', onMouse);
+      window.addEventListener('resize', onResize);
+      this._docHandlers = { onKey, onMouse, onResize };
+    },
+
+    _removeDocHandlers() {
+      if (!this._docHandlers) return;
+      document.removeEventListener('keydown', this._docHandlers.onKey);
+      document.removeEventListener('mousedown', this._docHandlers.onMouse);
+      window.removeEventListener('resize', this._docHandlers.onResize);
+      this._docHandlers = null;
+    },
+
+    _unitToMs(n, unit) {
+      const map = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+      const u = map[unit];
+      if (!u) return NaN;
+      return Math.floor(n * u);
+    },
+
+    _fmtDuration(ms) {
+      if (ms <= 0) return 'now';
+      const s = Math.floor(ms / 1000);
+      if (s < 60) return s + 's';
+      const m = Math.floor(s / 60);
+      if (m < 60) return m + 'm ' + (s % 60) + 's';
+      const h = Math.floor(m / 60);
+      if (h < 24) return h + 'h ' + (m % 60) + 'm';
+      const d = Math.floor(h / 24);
+      return d + 'd ' + (h % 24) + 'h';
+    },
+
+    async _fetch(method, suffix, body) {
+      const url = `/api/sessions/${encodeURIComponent(this.sessionId)}/schedules${suffix}`;
+      const opts = {
+        method,
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+      };
+      const token = (window.cwm && window.cwm.state && window.cwm.state.token) || window.AUTH_TOKEN;
+      if (token) opts.headers.authorization = 'Bearer ' + token;
+      if (body) opts.body = JSON.stringify(body);
+      const res = await fetch(url, opts);
+      let json = null;
+      try { json = await res.json(); } catch (_) {}
+      return { ok: res.ok, status: res.status, json };
+    },
+  };
+
+  window.SchedulePopover = SchedulePopover;
+})();

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -10007,3 +10007,125 @@ html {
 .files-cm-container .cm-scroller {
   overflow: auto;
 }
+
+/* ─── Schedule clock button ────────────────────────────── */
+/* Floating bottom-right of terminal pane, immediately to the left of the upload button. */
+.terminal-pane-schedule {
+  position: absolute; bottom: 12px; right: 52px; z-index: 5;
+  width: 32px; height: 32px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--surface0); border: 1px solid var(--surface1);
+  border-radius: 8px; color: var(--subtext0); cursor: pointer;
+  opacity: 0; transition: opacity 0.15s, background 0.15s;
+}
+.terminal-pane:not(.terminal-pane-empty):hover .terminal-pane-schedule,
+.terminal-pane-schedule:focus-visible { opacity: 0.7; }
+.terminal-pane-schedule:hover { opacity: 1 !important; background: var(--surface1); color: var(--text); }
+.terminal-pane-schedule .pane-schedule-count {
+  position: absolute; top: -2px; right: -2px;
+  min-width: 14px; height: 14px; padding: 0 3px;
+  background: var(--mauve); color: var(--base);
+  border-radius: 7px; font-size: 9px; font-weight: 600;
+  display: flex; align-items: center; justify-content: center;
+  pointer-events: none;
+}
+/* On mobile, keep the schedule button visible (unlike upload which uses the toolbar). */
+
+/* ─── Schedule popover ─────────────────────────────────── */
+.schedule-popover {
+  position: absolute;
+  z-index: 10004;
+  width: 360px; max-width: calc(100vw - 16px);
+  background: var(--surface0);
+  border: 1px solid var(--surface1);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  font-family: var(--font-sans, "Plus Jakarta Sans"), sans-serif;
+  font-size: 13px;
+  color: var(--text);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.schedule-popover-tabs {
+  display: flex; border-bottom: 1px solid var(--surface1);
+  background: var(--mantle);
+}
+.schedule-popover-tab {
+  flex: 1; padding: 8px 12px; text-align: center;
+  background: transparent; border: 0; color: var(--subtext0);
+  cursor: pointer; font-size: 12px; font-weight: 600;
+  transition: background 150ms, color 150ms;
+}
+.schedule-popover-tab:hover { background: var(--surface1); color: var(--text); }
+.schedule-popover-tab.active {
+  color: var(--mauve);
+  box-shadow: inset 0 -2px 0 var(--mauve);
+}
+.schedule-popover-body {
+  padding: 12px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+/* ─── Schedule popover form (Task 7) ──────────────────── */
+.schedule-form { display: flex; flex-direction: column; gap: 8px; }
+.schedule-form label { font-size: 11px; color: var(--subtext1); }
+/* Stack a wrapping label's caption above its input with a small gap so the
+   focus-state border does not crowd the label text. */
+.schedule-form > label:not(.row) { display: flex; flex-direction: column; gap: 6px; }
+/* Radio labels inside .row need the same in-label gap that the Repeat
+   checkbox label gets from its parent .row's flex gap. */
+.schedule-form .row label { display: inline-flex; align-items: center; gap: 6px; }
+.schedule-form input[type="text"],
+.schedule-form input[type="number"],
+.schedule-form input[type="date"],
+.schedule-form input[type="time"],
+.schedule-form input[type="datetime-local"],
+.schedule-form select {
+  width: 100%; padding: 6px 8px;
+  background: var(--base); color: var(--text);
+  border: 1px solid var(--surface1); border-radius: var(--radius-sm);
+  font: inherit;
+}
+.schedule-form .row { display: flex; gap: 6px; align-items: center; }
+.schedule-form .row > * { flex: 0 0 auto; }
+.schedule-form .row .num { width: 64px; }
+.schedule-form .row .unit { width: 80px; }
+.schedule-form .row .date { width: 140px; }
+.schedule-form .row .time { width: 100px; }
+.schedule-form .actions {
+  display: flex; justify-content: flex-end; gap: 8px; margin-top: 4px;
+}
+
+/* ─── Schedule list rows ──────────────────────────────── */
+.schedule-list { margin-top: 12px; border-top: 1px solid var(--surface1); padding-top: 8px; }
+.schedule-list-header {
+  font-size: 11px; color: var(--subtext0); text-transform: uppercase;
+  letter-spacing: 0.05em; margin-bottom: 4px;
+}
+.schedule-row {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 4px; border-radius: var(--radius-sm);
+}
+.schedule-row:hover { background: var(--surface1); }
+.schedule-row .glyph { width: 14px; text-align: center; opacity: 0.8; }
+.schedule-row .label { flex: 1; font-family: var(--font-mono, "JetBrains Mono"), monospace; font-size: 12px; }
+.schedule-row .when { color: var(--subtext0); font-size: 11px; }
+.schedule-row .trash {
+  background: transparent; border: 0; color: var(--subtext0);
+  cursor: pointer; padding: 2px 4px; border-radius: 4px;
+}
+.schedule-row .trash:hover { color: var(--red); background: var(--surface2); }
+.schedule-empty { color: var(--subtext0); font-size: 12px; padding: 8px 0; text-align: center; }
+
+/* ─── Schedule indicators (sidebar + pane title) ───────── */
+.session-schedule-clock,
+.pane-title-clock {
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--mauve);
+  vertical-align: middle;
+}
+/* Sidebar icon is prepended (icon → text), so margin sits on the right. */
+.session-schedule-clock { margin-right: 6px; }
+/* Pane-title icon sits inside the title span after the text. */
+.pane-title-clock { margin-left: 6px; opacity: 0.85; }

--- a/src/web/scheduler-routes.js
+++ b/src/web/scheduler-routes.js
@@ -1,0 +1,43 @@
+/**
+ * HTTP route adapters for the scheduler engine.
+ * Mounted by server.js (production) and by test/scheduler-api.test.js (tests).
+ */
+
+function mountScheduleRoutes(app, { requireAuth, scheduler, store }) {
+  app.get('/api/schedules/summary', requireAuth, (req, res) => {
+    res.json({ counts: scheduler.activeCounts() });
+  });
+
+  app.get('/api/sessions/:id/schedules', requireAuth, (req, res) => {
+    res.json({
+      active: scheduler.listActive(req.params.id),
+      history: scheduler.listHistory(req.params.id),
+    });
+  });
+
+  app.post('/api/sessions/:id/schedules', requireAuth, (req, res) => {
+    const sessionId = req.params.id;
+    if (!store.getSession(sessionId)) {
+      return res.status(404).json({ error: 'session not found' });
+    }
+    try {
+      const schedule = scheduler.create(sessionId, req.body || {});
+      res.json({ schedule });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  app.delete('/api/sessions/:id/schedules/history', requireAuth, (req, res) => {
+    scheduler.clearHistory(req.params.id);
+    res.json({ success: true });
+  });
+
+  app.delete('/api/sessions/:id/schedules/:scheduleId', requireAuth, (req, res) => {
+    const ok = scheduler.delete(req.params.scheduleId);
+    if (!ok) return res.status(404).json({ error: 'schedule not found' });
+    res.json({ success: true });
+  });
+}
+
+module.exports = { mountScheduleRoutes };

--- a/src/web/scheduler.js
+++ b/src/web/scheduler.js
@@ -1,0 +1,349 @@
+/**
+ * Scheduled messages engine.
+ *
+ * Fires shell commands into a pty session on a delay (one-off) or on repeat
+ * (recurring). State persists to ~/.myrlin/schedules.json so schedules survive
+ * server restarts. The engine is HTTP-agnostic: the route handlers in server.js
+ * are thin adapters.
+ *
+ * Constructor dependencies are injectable so the engine is unit-testable:
+ *   - ptyManager: must expose getSession(id) → { alive, pty: { write(s) } }
+ *   - store:      EventEmitter (the existing src/state/store Store), for session:deleted
+ *   - clock:      { now(): number } — defaults to Date
+ *   - schedule:   schedule(fn, ms) → handle; schedule.cancel(handle) — defaults to setTimeout
+ *   - dataFile:   absolute path to schedules.json — defaults to ~/.myrlin/schedules.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { getDataDir } = require('../utils/data-dir');
+
+const MAX_DELAY_MS = 30 * 86_400_000; // 30 days
+const MIN_DELAY_MS = 1_000;           // 1 second
+const MAX_COMMAND_BYTES = 2048;
+const HISTORY_CAP_PER_SESSION = 50;
+const SAVE_DEBOUNCE_MS = 200;
+// Gap between writing the message text and writing the Enter key. TUIs that
+// support bracketed-paste mode (Claude Code, etc) treat a single fast burst
+// ending in \r as a paste — and \r inside a paste becomes a literal newline
+// rather than a submit. Splitting the writes makes the second one register
+// as a real Enter keypress.
+const SUBMIT_DELAY_MS = 80;
+
+const DEFAULT_CLOCK = { now: () => Date.now() };
+function defaultSchedule(fn, ms) { return setTimeout(fn, ms); }
+defaultSchedule.cancel = (h) => clearTimeout(h);
+
+class Scheduler {
+  constructor({ dataFile, ptyManager, store, clock = DEFAULT_CLOCK, schedule = defaultSchedule } = {}) {
+    this.dataFile = dataFile || path.join(getDataDir(), 'schedules.json');
+    this.ptyManager = ptyManager;
+    this.store = store;
+    this.clock = clock;
+    this.schedule = schedule;
+
+    /** @type {Object.<string, Schedule>} */
+    this._schedules = {};
+    /** @type {Object.<string, HistoryRow[]>} */
+    this._history = {};
+    /** @type {Object.<string, any>} */
+    this._timers = {}; // scheduleId -> timer handle
+
+    this._saveTimer = null;
+    this._load();
+  }
+
+  // ── Persistence ────────────────────────────────────────────────
+
+  _load() {
+    try {
+      if (fs.existsSync(this.dataFile)) {
+        const raw = JSON.parse(fs.readFileSync(this.dataFile, 'utf8'));
+        this._schedules = raw.schedules || {};
+        this._history = raw.history || {};
+      }
+    } catch (_) {
+      this._schedules = {};
+      this._history = {};
+    }
+  }
+
+  _scheduleSave() {
+    if (this._saveTimer) return;
+    this._saveTimer = this.schedule(() => {
+      this._saveTimer = null;
+      this._writeSync();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  flushSync() {
+    if (this._saveTimer) {
+      this.schedule.cancel(this._saveTimer);
+      this._saveTimer = null;
+    }
+    this._writeSync();
+  }
+
+  _writeSync() {
+    const dir = path.dirname(this.dataFile);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const tmp = this.dataFile + '.tmp';
+    const payload = JSON.stringify({ schedules: this._schedules, history: this._history }, null, 2);
+    fs.writeFileSync(tmp, payload, 'utf8');
+    fs.renameSync(tmp, this.dataFile);
+  }
+
+  // ── CRUD ───────────────────────────────────────────────────────
+
+  /**
+   * Validate and create a schedule. Persists asynchronously (debounced).
+   * @param {string} sessionId
+   * @param {{command:string, kind:'once'|'recurring', delayMs?:number, fireAt?:number}} def
+   * @returns {Schedule}
+   */
+  create(sessionId, def) {
+    if (!sessionId || typeof sessionId !== 'string') throw new Error('sessionId required');
+    if (!def || typeof def !== 'object') throw new Error('def required');
+
+    const command = def.command;
+    if (typeof command !== 'string' || command.length === 0) throw new Error('command must be a non-empty string');
+    if (Buffer.byteLength(command, 'utf8') > MAX_COMMAND_BYTES) throw new Error('command exceeds 2KB');
+
+    const kind = def.kind;
+    if (kind !== 'once' && kind !== 'recurring') throw new Error('kind must be "once" or "recurring"');
+
+    const hasDelay = Number.isFinite(def.delayMs);
+    const hasFireAt = Number.isFinite(def.fireAt);
+    if (kind === 'recurring' && !hasDelay) throw new Error('recurring requires delayMs');
+    if (kind === 'recurring' && hasFireAt) throw new Error('recurring cannot use fireAt');
+    if (kind === 'once' && hasDelay && hasFireAt) throw new Error('exactly one of delayMs/fireAt for once');
+    if (kind === 'once' && !hasDelay && !hasFireAt) throw new Error('once requires delayMs or fireAt');
+
+    if (hasDelay) {
+      if (def.delayMs < MIN_DELAY_MS) throw new Error(`delayMs must be ≥ ${MIN_DELAY_MS}`);
+      if (def.delayMs > MAX_DELAY_MS) throw new Error(`delayMs must be ≤ ${MAX_DELAY_MS}`);
+    }
+
+    const now = this.clock.now();
+    if (hasFireAt && def.fireAt <= now) throw new Error('fireAt must be in the future');
+
+    const id = crypto.randomUUID();
+    const nextFireAt = hasFireAt ? def.fireAt : now + def.delayMs;
+    const s = {
+      id, sessionId, command, kind,
+      delayMs: hasDelay ? def.delayMs : undefined,
+      fireAt: hasFireAt ? def.fireAt : undefined,
+      nextFireAt,
+      createdAt: now,
+    };
+    this._schedules[id] = s;
+    this._scheduleSave();
+    // If the engine is already running, arm a timer for this new schedule.
+    // Without this, schedules created at runtime via the HTTP API would sit
+    // idle until the next server restart's boot-recovery loop.
+    if (this._started) this._armOne(id);
+    return s;
+  }
+
+  delete(scheduleId) {
+    if (!this._schedules[scheduleId]) return false;
+    const timer = this._timers[scheduleId];
+    if (timer) {
+      this.schedule.cancel(timer);
+      delete this._timers[scheduleId];
+    }
+    delete this._schedules[scheduleId];
+    this._scheduleSave();
+    return true;
+  }
+
+  listActive(sessionId) {
+    return Object.values(this._schedules)
+      .filter(s => s.sessionId === sessionId)
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  listHistory(sessionId) {
+    const rows = this._history[sessionId] || [];
+    // Stored newest-last; return newest-first
+    return [...rows].reverse();
+  }
+
+  clearHistory(sessionId) {
+    delete this._history[sessionId];
+    this._scheduleSave();
+  }
+
+  /**
+   * Active-schedule count per session id, for driving UI indicators
+   * (pane badges, sidebar clock icons) without requiring the frontend to
+   * fan out N requests across every visible session.
+   * @returns {Object<string, number>}
+   */
+  activeCounts() {
+    const out = {};
+    for (const s of Object.values(this._schedules)) {
+      out[s.sessionId] = (out[s.sessionId] || 0) + 1;
+    }
+    return out;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+
+  start() {
+    if (this._started) return;
+    this._started = true;
+
+    // Boot recovery: pre-process schedules whose nextFireAt has elapsed.
+    const now = this.clock.now();
+    for (const id of Object.keys(this._schedules)) {
+      const s = this._schedules[id];
+      if (s.nextFireAt < now) {
+        if (s.kind === 'once') {
+          this._appendHistory(s.sessionId, {
+            id: s.id, command: s.command,
+            firedAt: now, scheduledAt: s.nextFireAt,
+            status: 'skipped', skipReason: 'missed-while-down', skipCount: 1,
+          });
+          delete this._schedules[id];
+        } else {
+          // recurring: no catch-up, advance to now + delayMs
+          s.nextFireAt = now + s.delayMs;
+        }
+      }
+    }
+    this._scheduleSave();
+
+    // Arm timers for everything still active
+    for (const id of Object.keys(this._schedules)) {
+      this._armOne(id);
+    }
+
+    // Subscribe to store cleanup
+    if (this.store && typeof this.store.on === 'function') {
+      this._onSessionDeleted = ({ id }) => this._handleSessionDeleted(id);
+      this.store.on('session:deleted', this._onSessionDeleted);
+    }
+  }
+
+  stop() {
+    this._started = false;
+    for (const id of Object.keys(this._timers)) {
+      this.schedule.cancel(this._timers[id]);
+    }
+    this._timers = {};
+    if (this._saveTimer) {
+      this.schedule.cancel(this._saveTimer);
+      this._saveTimer = null;
+      this._writeSync();
+    }
+    if (this.store && this._onSessionDeleted) {
+      this.store.off('session:deleted', this._onSessionDeleted);
+      this._onSessionDeleted = null;
+    }
+  }
+
+  _armOne(scheduleId) {
+    const s = this._schedules[scheduleId];
+    if (!s) return;
+    const delay = Math.max(0, s.nextFireAt - this.clock.now());
+    this._timers[scheduleId] = this.schedule(() => this._fire(scheduleId), delay);
+  }
+
+  // ── Fire flow ─────────────────────────────────────────────────
+
+  _fire(scheduleId) {
+    const s = this._schedules[scheduleId];
+    if (!s) return;
+    delete this._timers[scheduleId];
+
+    const session = this.ptyManager && this.ptyManager.getSession(s.sessionId);
+    const alive = !!(session && session.alive);
+    const scheduledAt = s.nextFireAt;
+    const firedAt = this.clock.now();
+
+    if (!alive) {
+      this._appendHistory(s.sessionId, {
+        id: s.id, command: s.command, firedAt, scheduledAt,
+        status: 'skipped', skipReason: 'session-not-running', skipCount: 1,
+      });
+      if (s.kind === 'once') {
+        delete this._schedules[s.id];
+      } else {
+        s.nextFireAt = firedAt + s.delayMs;
+        this._armOne(s.id);
+      }
+      this._scheduleSave();
+      return;
+    }
+
+    // Success path. Write the message text first, then fire the Enter
+    // key as a separate write after a short gap (see SUBMIT_DELAY_MS comment).
+    try {
+      session.pty.write(s.command);
+    } catch (err) {
+      console.error('[Scheduler] pty.write failed:', err.message);
+    }
+    this.schedule(() => {
+      const live = this.ptyManager && this.ptyManager.getSession(s.sessionId);
+      if (!live || !live.alive) return;
+      try { live.pty.write('\r'); }
+      catch (err) { console.error('[Scheduler] pty.write \\r failed:', err.message); }
+    }, SUBMIT_DELAY_MS);
+
+    this._appendHistory(s.sessionId, {
+      id: s.id, command: s.command, firedAt, scheduledAt,
+      status: 'success', skipReason: null, skipCount: 1,
+    });
+
+    if (s.kind === 'once') {
+      delete this._schedules[s.id];
+    } else {
+      s.nextFireAt = firedAt + s.delayMs;
+      this._armOne(s.id);
+    }
+    this._scheduleSave();
+  }
+
+  _appendHistory(sessionId, row) {
+    if (!this._history[sessionId]) this._history[sessionId] = [];
+    const arr = this._history[sessionId];
+    const last = arr[arr.length - 1];
+    const canCollapse =
+      last
+      && last.status === 'skipped'
+      && row.status === 'skipped'
+      && last.id === row.id
+      && last.skipReason === row.skipReason;
+    if (canCollapse) {
+      last.skipCount = (last.skipCount || 1) + 1;
+      last.firedAt = row.firedAt;
+    } else {
+      arr.push(row);
+    }
+    if (arr.length > HISTORY_CAP_PER_SESSION) {
+      this._history[sessionId] = arr.slice(-HISTORY_CAP_PER_SESSION);
+    }
+  }
+
+  _handleSessionDeleted(sessionId) {
+    let changed = false;
+    for (const id of Object.keys(this._schedules)) {
+      if (this._schedules[id].sessionId === sessionId) {
+        const timer = this._timers[id];
+        if (timer) this.schedule.cancel(timer);
+        delete this._timers[id];
+        delete this._schedules[id];
+        changed = true;
+      }
+    }
+    if (this._history[sessionId]) {
+      delete this._history[sessionId];
+      changed = true;
+    }
+    if (changed) this._scheduleSave();
+  }
+}
+
+module.exports = { Scheduler, MIN_DELAY_MS, MAX_DELAY_MS, MAX_COMMAND_BYTES, HISTORY_CAP_PER_SESSION };

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -7991,6 +7991,7 @@ app.use((err, req, res, _next) => {
  */
 // Reference to PTY manager for cleanup on shutdown
 let _ptyManager = null;
+let _scheduler = null;
 
 /**
  * Backfill resumeSessionId for sessions that have a workingDir but no resumeSessionId.
@@ -8045,8 +8046,18 @@ function startServer(port = 3456, host = '127.0.0.1') {
   const { ptyWss, ptyManager } = attachPtyWebSocket(server);
   _ptyManager = ptyManager;
 
-  // Cleanup tunnels and PTY sessions on shutdown
+  // ─── Scheduler ───────────────────────────────────────────────
+  const { Scheduler } = require('./scheduler');
+  const { mountScheduleRoutes } = require('./scheduler-routes');
+  _scheduler = new Scheduler({ ptyManager: _ptyManager, store: getStore() });
+  _scheduler.start();
+  mountScheduleRoutes(app, { requireAuth, scheduler: _scheduler, store: getStore() });
+
+  // Cleanup tunnels, scheduler, and PTY sessions on shutdown
   const cleanup = () => {
+    if (_scheduler) {
+      try { _scheduler.stop(); } catch (_) {}
+    }
     if (_ptyManager) {
       try { _ptyManager.destroyAll(); } catch (_) {}
     }

--- a/test/scheduler-api.test.js
+++ b/test/scheduler-api.test.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * HTTP tests for /api/sessions/:id/schedules.
+ *
+ * Mounts a minimal Express app with just the scheduler routes attached. Auth
+ * is a tiny pass-through so we can focus on validation + plumbing.
+ *
+ * Usage: node test/scheduler-api.test.js
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const http = require('http');
+const express = require('express');
+const { EventEmitter } = require('events');
+
+let passed = 0, failed = 0;
+async function test(name, fn) {
+  try { await fn(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  catch (err) { failed++; console.log(`  \x1b[31m✗ ${name}\n    ${err.message}\x1b[0m`); }
+}
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+function assertEqual(a, b, m) { if (a !== b) throw new Error(m || `expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); }
+
+function req(server, method, urlPath, { token = 'good', body } = {}) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const r = http.request({
+      hostname: '127.0.0.1', port: server.address().port, path: urlPath, method,
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { authorization: 'Bearer ' + token } : {}),
+        ...(data ? { 'content-length': Buffer.byteLength(data) } : {}),
+      },
+    }, (res) => {
+      let buf = '';
+      res.on('data', d => buf += d);
+      res.on('end', () => {
+        let parsed = null;
+        try { parsed = buf ? JSON.parse(buf) : null; } catch (_) { parsed = buf; }
+        resolve({ status: res.statusCode, body: parsed });
+      });
+    });
+    r.on('error', reject);
+    if (data) r.write(data);
+    r.end();
+  });
+}
+
+function buildHarness({ knownSessions = ['sess-A'] } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-api-'));
+  const dataFile = path.join(dir, 'schedules.json');
+  delete require.cache[require.resolve('../src/web/scheduler')];
+  const { Scheduler } = require('../src/web/scheduler');
+  const ptyManager = {
+    sessions: new Map(knownSessions.map(id => [id, { alive: true, pty: { write() {} } }])),
+    getSession(id) { return this.sessions.get(id); },
+  };
+  const store = Object.assign(new EventEmitter(), {
+    getSession(id) { return knownSessions.includes(id) ? { id } : null; },
+  });
+  const sched = new Scheduler({ dataFile, ptyManager, store });
+  sched.start();
+
+  const app = express();
+  app.use(express.json());
+  // Tiny fake auth middleware: header `authorization: Bearer good` passes.
+  function requireAuth(req, res, next) {
+    if ((req.headers.authorization || '') === 'Bearer good') return next();
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  // Mount the routes (test imports the same factory used by server.js)
+  delete require.cache[require.resolve('../src/web/scheduler-routes')];
+  const { mountScheduleRoutes } = require('../src/web/scheduler-routes');
+  mountScheduleRoutes(app, { requireAuth, scheduler: sched, store });
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve({ server, sched, store, ptyManager, dataFile }));
+  });
+}
+
+(async () => {
+  console.log('\n  Schedule API');
+
+  await test('GET unknown session → 200, empty active+history', async () => {
+    const h = await buildHarness();
+    const r = await req(h.server, 'GET', '/api/sessions/sess-A/schedules');
+    assertEqual(r.status, 200);
+    assertEqual(r.body.active.length, 0);
+    assertEqual(r.body.history.length, 0);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('GET without auth → 401', async () => {
+    const h = await buildHarness();
+    const r = await req(h.server, 'GET', '/api/sessions/sess-A/schedules', { token: null });
+    assertEqual(r.status, 401);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('POST creates schedule, GET returns it', async () => {
+    const h = await buildHarness();
+    const create = await req(h.server, 'POST', '/api/sessions/sess-A/schedules', {
+      body: { command: 'npm test', kind: 'once', delayMs: 60_000 },
+    });
+    assertEqual(create.status, 200);
+    assert(create.body.schedule.id);
+    const list = await req(h.server, 'GET', '/api/sessions/sess-A/schedules');
+    assertEqual(list.body.active.length, 1);
+    assertEqual(list.body.active[0].command, 'npm test');
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('POST validation: empty command → 400', async () => {
+    const h = await buildHarness();
+    const r = await req(h.server, 'POST', '/api/sessions/sess-A/schedules', {
+      body: { command: '', kind: 'once', delayMs: 60_000 },
+    });
+    assertEqual(r.status, 400);
+    assert(r.body.error);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('POST validation: delayMs below 1s → 400', async () => {
+    const h = await buildHarness();
+    const r = await req(h.server, 'POST', '/api/sessions/sess-A/schedules', {
+      body: { command: 'x', kind: 'once', delayMs: 100 },
+    });
+    assertEqual(r.status, 400);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('POST unknown session → 404', async () => {
+    const h = await buildHarness({ knownSessions: ['sess-A'] });
+    const r = await req(h.server, 'POST', '/api/sessions/sess-MISSING/schedules', {
+      body: { command: 'x', kind: 'once', delayMs: 60_000 },
+    });
+    assertEqual(r.status, 404);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('DELETE schedule removes it', async () => {
+    const h = await buildHarness();
+    const c = await req(h.server, 'POST', '/api/sessions/sess-A/schedules', {
+      body: { command: 'x', kind: 'once', delayMs: 60_000 },
+    });
+    const id = c.body.schedule.id;
+    const d = await req(h.server, 'DELETE', `/api/sessions/sess-A/schedules/${id}`);
+    assertEqual(d.status, 200);
+    assertEqual(d.body.success, true);
+    const list = await req(h.server, 'GET', '/api/sessions/sess-A/schedules');
+    assertEqual(list.body.active.length, 0);
+    h.server.close(); h.sched.stop();
+  });
+
+  await test('DELETE history clears history block', async () => {
+    const h = await buildHarness();
+    h.sched._appendHistory('sess-A', {
+      id: 'x', command: 'cmd', firedAt: 1, scheduledAt: 1,
+      status: 'success', skipReason: null, skipCount: 1,
+    });
+    h.sched.flushSync();
+    const r = await req(h.server, 'DELETE', '/api/sessions/sess-A/schedules/history');
+    assertEqual(r.status, 200);
+    const list = await req(h.server, 'GET', '/api/sessions/sess-A/schedules');
+    assertEqual(list.body.history.length, 0);
+    h.server.close(); h.sched.stop();
+  });
+
+  console.log(`\n  Results: ${passed} passed, ${failed} failed`);
+  process.exit(failed > 0 ? 1 : 0);
+})();

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+/**
+ * Tests for src/web/scheduler.js — engine with injected clock + fake ptyManager.
+ * Usage: node test/scheduler.test.js
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { EventEmitter } = require('events');
+
+let passed = 0, failed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  catch (err) { failed++; console.log(`  \x1b[31m✗ ${name}\n    ${err.message}\x1b[0m`); }
+}
+async function atest(name, fn) {
+  try { await fn(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`); }
+  catch (err) { failed++; console.log(`  \x1b[31m✗ ${name}\n    ${err.message}\x1b[0m`); }
+}
+function assert(c, m) { if (!c) throw new Error(m || 'assertion failed'); }
+function assertEqual(a, b, m) { if (a !== b) throw new Error(m || `expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); }
+function assertDeepEqual(a, b, m) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) throw new Error(m || `expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+}
+
+// ── Test fixtures ─────────────────────────────────────────────
+function makeClock(start = 1_700_000_000_000) {
+  let now = start;
+  return {
+    now: () => now,
+    advance: (ms) => { now += ms; },
+    set: (t) => { now = t; },
+  };
+}
+
+function makePtyManager() {
+  const writes = [];
+  const sessions = new Map();
+  return {
+    writes,
+    setSession(id, alive) {
+      sessions.set(id, { alive, pty: { write: (data) => writes.push({ id, data }) } });
+    },
+    removeSession(id) { sessions.delete(id); },
+    getSession(id) { return sessions.get(id); },
+  };
+}
+
+function makeStore() {
+  const ee = new EventEmitter();
+  return ee;
+}
+
+function makeScheduler({ clock = makeClock(), ptyManager = makePtyManager(), store = makeStore(), dataFile } = {}) {
+  if (!dataFile) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-test-'));
+    dataFile = path.join(dir, 'schedules.json');
+  }
+  // Lazy-require so each test gets a fresh module (caches no state — but be safe).
+  delete require.cache[require.resolve('../src/web/scheduler')];
+  const { Scheduler } = require('../src/web/scheduler');
+  // schedule(fn, ms) is the timer abstraction — tests pass a stub that records calls.
+  const armed = [];
+  const schedule = (fn, ms) => {
+    const handle = { fn, ms, cancelled: false };
+    armed.push(handle);
+    return handle;
+  };
+  schedule.cancel = (handle) => { handle.cancelled = true; };
+  return {
+    sched: new Scheduler({ dataFile, ptyManager, store, clock, schedule }),
+    clock, ptyManager, store, dataFile, armed,
+  };
+}
+
+console.log('\n  Scheduler — surface + persistence');
+
+test('create() returns full schedule with id, persists', () => {
+  const { sched, clock, dataFile } = makeScheduler();
+  const def = { command: 'npm test', kind: 'once', delayMs: 60_000 };
+  const s = sched.create('sess-A', def);
+  assert(s.id && s.id.length > 0, 'id present');
+  assertEqual(s.sessionId, 'sess-A');
+  assertEqual(s.command, 'npm test');
+  assertEqual(s.kind, 'once');
+  assertEqual(s.delayMs, 60_000);
+  assertEqual(s.nextFireAt, clock.now() + 60_000);
+  assertEqual(s.createdAt, clock.now());
+  sched.flushSync();
+  const raw = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+  assertEqual(Object.keys(raw.schedules).length, 1);
+});
+
+test('listActive() returns only that session, oldest first', () => {
+  const { sched, clock } = makeScheduler();
+  const a = sched.create('sess-A', { command: 'one', kind: 'once', delayMs: 1000 });
+  clock.advance(10);
+  const b = sched.create('sess-A', { command: 'two', kind: 'once', delayMs: 1000 });
+  clock.advance(10);
+  sched.create('sess-B', { command: 'other', kind: 'once', delayMs: 1000 });
+  const list = sched.listActive('sess-A');
+  assertEqual(list.length, 2);
+  assertEqual(list[0].id, a.id);
+  assertEqual(list[1].id, b.id);
+});
+
+test('delete() removes and persists', () => {
+  const { sched, dataFile } = makeScheduler();
+  const s = sched.create('sess-A', { command: 'x', kind: 'once', delayMs: 1000 });
+  sched.delete(s.id);
+  sched.flushSync();
+  const raw = JSON.parse(fs.readFileSync(dataFile, 'utf8'));
+  assertEqual(Object.keys(raw.schedules).length, 0);
+});
+
+test('create() validates kind', () => {
+  const { sched } = makeScheduler();
+  let threw = false;
+  try { sched.create('s', { command: 'x', kind: 'forever', delayMs: 1000 }); }
+  catch (_) { threw = true; }
+  assert(threw, 'should reject invalid kind');
+});
+
+test('create() validates command non-empty and ≤2KB', () => {
+  const { sched } = makeScheduler();
+  let threw = 0;
+  try { sched.create('s', { command: '', kind: 'once', delayMs: 1000 }); } catch (_) { threw++; }
+  try { sched.create('s', { command: 'x'.repeat(2049), kind: 'once', delayMs: 1000 }); } catch (_) { threw++; }
+  assertEqual(threw, 2);
+});
+
+test('create() validates delayMs range', () => {
+  const { sched } = makeScheduler();
+  let threw = 0;
+  try { sched.create('s', { command: 'x', kind: 'once', delayMs: 999 }); } catch (_) { threw++; }
+  try { sched.create('s', { command: 'x', kind: 'once', delayMs: 31 * 86400000 }); } catch (_) { threw++; }
+  assertEqual(threw, 2);
+});
+
+test('create() with absolute fireAt computes nextFireAt = fireAt', () => {
+  const { sched, clock } = makeScheduler();
+  const at = clock.now() + 5_000;
+  const s = sched.create('sess-A', { command: 'x', kind: 'once', fireAt: at });
+  assertEqual(s.fireAt, at);
+  assertEqual(s.nextFireAt, at);
+});
+
+test('round-trip: persisted schedules survive reload', () => {
+  const fixture = makeScheduler();
+  fixture.sched.create('sess-A', { command: 'persist me', kind: 'recurring', delayMs: 60_000 });
+  fixture.sched.flushSync();
+  // Reload from same dataFile in a fresh instance
+  delete require.cache[require.resolve('../src/web/scheduler')];
+  const { Scheduler } = require('../src/web/scheduler');
+  const fresh = new Scheduler({
+    dataFile: fixture.dataFile,
+    ptyManager: fixture.ptyManager,
+    store: fixture.store,
+    clock: fixture.clock,
+    schedule: () => ({ cancelled: false }),
+  });
+  assertEqual(fresh.listActive('sess-A').length, 1);
+  assertEqual(fresh.listActive('sess-A')[0].command, 'persist me');
+});
+
+console.log('\n  Scheduler — fire flow (success path)');
+
+test('start() arms a timer for every active schedule', () => {
+  const f = makeScheduler();
+  f.sched.create('sess-A', { command: 'x', kind: 'once', delayMs: 5000 });
+  f.sched.create('sess-A', { command: 'y', kind: 'recurring', delayMs: 10000 });
+  f.sched.start();
+  // Two timers armed (excluding the save-debounce timer which uses same `schedule` stub)
+  const fireTimers = f.armed.filter(h => h.ms === 5000 || h.ms === 10000);
+  assertEqual(fireTimers.length, 2);
+});
+
+test('fire() writes message then \\r as separate writes (paste-mode safe)', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', /*alive*/ true);
+  const s = f.sched.create('sess-A', { command: 'npm test', kind: 'once', delayMs: 1000 });
+  f.sched.start();
+  const handle = f.armed.find(h => h.ms === 1000);
+  f.clock.advance(1000);
+  handle.fn();
+  // First write: just the message text, no carriage return.
+  assertEqual(f.ptyManager.writes.length, 1);
+  assertEqual(f.ptyManager.writes[0].id, 'sess-A');
+  assertEqual(f.ptyManager.writes[0].data, 'npm test');
+  // The Enter is scheduled separately. Find and fire the submit timer.
+  const submit = f.armed.find(h => h.ms === 80 && !h.cancelled);
+  assert(submit, 'expected submit timer scheduled');
+  submit.fn();
+  assertEqual(f.ptyManager.writes.length, 2);
+  assertEqual(f.ptyManager.writes[1].data, '\r');
+});
+
+test('one-off schedule deletes after successful fire', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', true);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'once', delayMs: 1000 });
+  f.sched.start();
+  const handle = f.armed.find(h => h.ms === 1000);
+  f.clock.advance(1000);
+  handle.fn();
+  assertEqual(f.sched.listActive('sess-A').length, 0);
+});
+
+test('recurring schedule re-arms with delayMs after fire', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', true);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  const handle1 = f.armed.find(h => h.ms === 5000);
+  f.clock.advance(5000);
+  handle1.fn();
+  // Schedule still active, nextFireAt advanced
+  const active = f.sched.listActive('sess-A');
+  assertEqual(active.length, 1);
+  assertEqual(active[0].nextFireAt, f.clock.now() + 5000);
+  // A new timer armed for next fire
+  const next = f.armed.filter(h => h.ms === 5000);
+  assertEqual(next.length, 2);
+});
+
+test('create() after start() arms a timer immediately', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', true);
+  f.sched.start();
+  const s = f.sched.create('sess-A', { command: 'live', kind: 'once', delayMs: 7000 });
+  // A 7s timer must be armed (in addition to any save-debounce 200ms timers)
+  assert(f.armed.some(h => h.ms === 7000), 'expected 7s timer armed for runtime-created schedule');
+  // And firing it should reach the pty (text first, then \r via submit timer)
+  f.clock.advance(7000);
+  f.armed.find(h => h.ms === 7000).fn();
+  assertEqual(f.ptyManager.writes.length, 1);
+  assertEqual(f.ptyManager.writes[0].data, 'live');
+  f.armed.find(h => h.ms === 80 && !h.cancelled).fn();
+  assertEqual(f.ptyManager.writes.length, 2);
+  assertEqual(f.ptyManager.writes[1].data, '\r');
+});
+
+test('successful fire appends a success history row', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', true);
+  const s = f.sched.create('sess-A', { command: 'echo hi', kind: 'once', delayMs: 1000 });
+  f.sched.start();
+  const handle = f.armed.find(h => h.ms === 1000);
+  f.clock.advance(1000);
+  handle.fn();
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 1);
+  assertEqual(hist[0].status, 'success');
+  assertEqual(hist[0].command, 'echo hi');
+  assertEqual(hist[0].firedAt, f.clock.now());
+  assertEqual(hist[0].scheduledAt, s.nextFireAt);
+});
+
+console.log('\n  Scheduler — skip handling');
+
+test('stopped pty fires skipped row, recurring re-arms', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', /*alive*/ false);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  f.armed.find(h => h.ms === 5000).fn();
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 1);
+  assertEqual(hist[0].status, 'skipped');
+  assertEqual(hist[0].skipReason, 'session-not-running');
+  // Recurring re-armed
+  const active = f.sched.listActive('sess-A');
+  assertEqual(active.length, 1);
+});
+
+test('stopped pty + once kind deletes the schedule', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', false);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'once', delayMs: 1000 });
+  f.sched.start();
+  f.armed.find(h => h.ms === 1000).fn();
+  assertEqual(f.sched.listActive('sess-A').length, 0);
+  assertEqual(f.sched.listHistory('sess-A').length, 1);
+});
+
+test('three consecutive same-id skip rows collapse to one with skipCount=3', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', false);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  // Fire three times in a row
+  for (let i = 0; i < 3; i++) {
+    f.clock.advance(5000);
+    const handle = f.armed.filter(h => h.ms === 5000).pop();
+    handle.fn();
+  }
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 1);
+  assertEqual(hist[0].skipCount, 3);
+  assertEqual(hist[0].status, 'skipped');
+});
+
+test('success between skips breaks collapse — 3 distinct rows', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', false);
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  // skip
+  f.clock.advance(5000); f.armed.filter(h => h.ms === 5000).pop().fn();
+  // bring pty up, success
+  f.ptyManager.setSession('sess-A', true);
+  f.clock.advance(5000); f.armed.filter(h => h.ms === 5000).pop().fn();
+  // pty down again, skip
+  f.ptyManager.setSession('sess-A', false);
+  f.clock.advance(5000); f.armed.filter(h => h.ms === 5000).pop().fn();
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 3);
+  // Newest first
+  assertEqual(hist[0].status, 'skipped');
+  assertEqual(hist[1].status, 'success');
+  assertEqual(hist[2].status, 'skipped');
+});
+
+test('different schedule ids do not collapse together', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', false);
+  const s1 = f.sched.create('sess-A', { command: 'a', kind: 'recurring', delayMs: 5000 });
+  const s2 = f.sched.create('sess-A', { command: 'b', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  f.armed.filter(h => h.ms === 5000).forEach(h => h.fn()); // both fire once
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 2);
+  assertEqual(hist[0].skipCount, 1);
+  assertEqual(hist[1].skipCount, 1);
+});
+
+test('history cap: 51 appends → 50 newest retained', () => {
+  const f = makeScheduler();
+  // Bypass through internal API for speed
+  for (let i = 0; i < 51; i++) {
+    f.sched._appendHistory('sess-A', {
+      id: 'id-' + i, command: 'c-' + i, firedAt: 1000 + i, scheduledAt: 1000 + i,
+      status: 'success', skipReason: null, skipCount: 1,
+    });
+  }
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 50);
+  // Newest first → command "c-50"
+  assertEqual(hist[0].command, 'c-50');
+  // Oldest retained is c-1 (c-0 was pruned)
+  assertEqual(hist[hist.length - 1].command, 'c-1');
+});
+
+console.log('\n  Scheduler — boot recovery');
+
+test('start(): missed once → skipped+deleted, no timer armed', () => {
+  // Build a state file directly so the next instance boots with stale state
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-test-'));
+  const dataFile = path.join(dir, 'schedules.json');
+  fs.writeFileSync(dataFile, JSON.stringify({
+    schedules: {
+      'sched-1': {
+        id: 'sched-1', sessionId: 'sess-A', command: 'late',
+        kind: 'once', delayMs: 60000,
+        nextFireAt: 1000,            // way in the past (vs clock 1.7e12)
+        createdAt: 500,
+      },
+    },
+    history: {},
+  }));
+  const f = makeScheduler({ dataFile });
+  f.sched.start();
+  assertEqual(f.sched.listActive('sess-A').length, 0);
+  const hist = f.sched.listHistory('sess-A');
+  assertEqual(hist.length, 1);
+  assertEqual(hist[0].status, 'skipped');
+  assertEqual(hist[0].skipReason, 'missed-while-down');
+});
+
+test('start(): missed recurring → advanced, armed, no history row', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-test-'));
+  const dataFile = path.join(dir, 'schedules.json');
+  fs.writeFileSync(dataFile, JSON.stringify({
+    schedules: {
+      'sched-2': {
+        id: 'sched-2', sessionId: 'sess-A', command: 'tick',
+        kind: 'recurring', delayMs: 5000,
+        nextFireAt: 1000,
+        createdAt: 500,
+      },
+    },
+    history: {},
+  }));
+  const f = makeScheduler({ dataFile });
+  f.sched.start();
+  const active = f.sched.listActive('sess-A');
+  assertEqual(active.length, 1);
+  assertEqual(active[0].nextFireAt, f.clock.now() + 5000);
+  // Timer armed
+  assert(f.armed.some(h => h.ms === 5000), 'timer armed for recurring');
+  // No history row
+  assertEqual(f.sched.listHistory('sess-A').length, 0);
+});
+
+test('start(): future once → timer armed for the remaining delay', () => {
+  const f = makeScheduler();
+  const s = f.sched.create('sess-A', { command: 'x', kind: 'once', delayMs: 30_000 });
+  f.sched.start();
+  assert(f.armed.some(h => h.ms === 30_000), 'expected 30s timer armed');
+});
+
+console.log('\n  Scheduler — store cleanup');
+
+test('session:deleted clears that session\'s schedules and history', () => {
+  const f = makeScheduler();
+  f.ptyManager.setSession('sess-A', false);
+  f.sched.create('sess-A', { command: 'x', kind: 'recurring', delayMs: 5000 });
+  f.sched.create('sess-B', { command: 'y', kind: 'recurring', delayMs: 5000 });
+  f.sched.start();
+  // Drop a history row for sess-A
+  f.armed.filter(h => h.ms === 5000)[0].fn();
+  assert(f.sched.listActive('sess-A').length > 0);
+  assert(f.sched.listHistory('sess-A').length > 0);
+  // Emit deletion
+  f.store.emit('session:deleted', { id: 'sess-A' });
+  assertEqual(f.sched.listActive('sess-A').length, 0);
+  assertEqual(f.sched.listHistory('sess-A').length, 0);
+  // sess-B untouched
+  assertEqual(f.sched.listActive('sess-B').length, 1);
+});
+
+console.log(`\n  Results: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary                                                                                                                                             
  Adds a server-side scheduler and a per-pane popover UI for queuing shell commands to fire into a Claude session later — once after a delay, at an absolute time, or repeatedly on an interval.                                                                                                           
                                                                                                                                                       
  **Backend** (`src/web/scheduler.js`, `src/web/scheduler-routes.js`)                                                                                    
  - Pure-JS engine with injectable clock, timer, ptyManager, and store                                                                                 
  - Persists to `~/.myrlin/schedules.json` (atomic tmp+rename, debounced 200 ms)                                                                         
  - Boot recovery: missed once-shots → `skipped: missed-while-down`; missed recurring → `nextFireAt` advanced (no catch-up)                              
  - Skip handling when the pty is stopped, with consecutive same-(id, reason) collapse and a 50-row history cap per session                              
  - Cleans a session's schedules + history on `store.emit('session:deleted')`                                                                            
  - Splits message text and `\r` into two writes (~80 ms gap) so paste-mode TUIs treat the second one as Enter rather than swallowing it inside a paste burst                                                                                                                                                  
  - HTTP: `GET/POST/DELETE /api/sessions/:id/schedules`, `DELETE …/schedules/history`, `GET /api/schedules/summary`                                      
  - Lifecycle wired into `startServer()` / shutdown                                                                                                      
  **Frontend** (`src/web/public/schedules.js`, `app.js`, `styles.css`, `index.html`)                                                                   
  - Floating clock button next to the upload-image button on every terminal pane                                                                         
  - Popover with Active / History tabs, opens above-and-left of the button                                                                             
  - Active tab: form (Message text, when in/at, Repeat) with validation; list with relative-time labels (1 s ticker) and trash buttons; auto-focuses the message input on open                                                                                                                                  
  - "at" picker split into a date input (prefilled to today) and a time input (empty)                                                                    
  - History tab: newest-first, status icons, skip-collapse rendering ("Skipped 3 — session not running")                                                 
  - 5 s polling while popover is open; 10 s global poll of `/api/schedules/summary` drives:                                                              
    - count badge on the clock button                                                                                                                    
    - inline clock icon inside the pane title bar                                                                                                        
    - inline clock icon prepended to sidebar session items (`.session-item` and `.ws-session-item`)                                                      
  - Single SVG `<symbol id="icon-clock">` referenced everywhere via `<use>`                                                                              
                                                                                                                                                         
  ## Tests                                                                                                                                               
  - `test/scheduler.test.js` — 24 tests covering surface, persistence, fire flow, skip + collapse, boot recovery, store cleanup, runtime arming, paste-safe write split                                                                                                                                 
  - `test/scheduler-api.test.js` — 8 tests covering routes + auth + validation                                                                           
  - Existing suite (`npm test`) — 58 passing, no regressions 
<img width="407" height="403" alt="image" src="https://github.com/user-attachments/assets/40171002-962d-4828-a199-5ba079502548" />
