### PR TITLE
fix(terminal): Shift+Enter should insert a newline instead of submitting

### DIFF
--- a/src/web/public/terminal.js
+++ b/src/web/public/terminal.js
@@ -384,10 +384,18 @@ class TerminalPane {
           return false;
         }
 
-        // Shift+Enter: send newline instead of carriage return
+        // Shift+Enter: send ESC+CR — Anthropic's documented "newline in input"
+        // sequence. Plain \n didn't work because Ink-based TUIs (Claude Code)
+        // treat both \n and \r as submit; \x1b\r is interpreted as "newline,
+        // not submit". Matches the keybinding recipe shipped by /terminal-setup.
+        // preventDefault is required: returning false only stops xterm from
+        // handling the key but does NOT prevent the browser from inserting a
+        // newline into the hidden textarea, which then fires onData with \r
+        // and submits — same pattern as the Ctrl+V handler above.
         if (e.key === 'Enter' && e.shiftKey) {
+          e.preventDefault();
           if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-            this.ws.send(JSON.stringify({ type: 'input', data: '\n' }));
+            this.ws.send(JSON.stringify({ type: 'input', data: '\x1b\r' }));
           }
           return false;
         }


### PR DESCRIPTION
The pane's Shift+Enter handler now sends ESC+CR (\x1b\r), the sequence Anthropic's /terminal-setup ships in its VS Code keybinding recipe. Ink-based TUIs (Claude Code) treat both \n and \r as a submit, so the previous \n made Shift+Enter behave identically to Enter; ESC+CR is interpreted as "newline in input, do not submit."

Also calls e.preventDefault() in the custom key handler. Returning false from attachCustomKeyEventHandler only stops xterm.js from processing the key — without preventDefault, the browser still inserts a newline into xterm's hidden textarea, whose input handler fires onData with \r and submits anyway. Mirrors the existing Ctrl+V handler which has the same guard for the same reason.