### PR TITLE
Fix: sessions binding to the wrong claude session/transcript

### DIFF
--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -515,7 +515,12 @@ class PtySessionManager {
               if (preSnapshot.has(dirName + '/' + f)) continue;
               let stat;
               try { stat = fs.statSync(path.join(projDir, f)); } catch (_) { continue; }
-              fresh.push({ dirName, name: f, mtime: stat.mtimeMs });
+              // Prefer birthtime (true creation time) when available — that
+              // is the right semantic for "which JSONL did this PTY produce."
+              // Fall back to mtime on filesystems that don't track birthtime
+              // reliably (some older Linux/btrfs/zfs return 0 or mtime).
+              const bornAt = stat.birthtimeMs || stat.mtimeMs;
+              fresh.push({ dirName, name: f, bornAt });
             }
           }
 
@@ -524,7 +529,7 @@ class PtySessionManager {
             return;
           }
 
-          fresh.sort((a, b) => b.mtime - a.mtime);
+          fresh.sort((a, b) => b.bornAt - a.bornAt);
           const uuid = fresh[0].name.replace('.jsonl', '');
           console.log(`[PTY] Detected Claude session UUID for ${sessionId}: ${uuid}`);
 

--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -117,6 +117,105 @@ function cwdFromJsonl(sessionId) {
 const MAX_SCROLLBACK_CHARS = 100 * 1024; // 100KB
 
 /**
+ * Watch one or more directories for the appearance of a *.jsonl file that is
+ * not in the pre-call snapshot. Emits exactly one result.
+ *
+ * Hybrid strategy:
+ *   1. fs.watch is registered on each candidate dir that exists at call time.
+ *      'rename' events for new .jsonl files resolve immediately.
+ *   2. At t+timeoutMs, a final rescan diffs the live directory listing against
+ *      the snapshot and picks the freshest by birthtime/mtime. Catches macOS
+ *      FSEvents drops and the cold-start case where the candidate dir didn't
+ *      exist when fs.watch was first attempted.
+ *   3. cleanup() is idempotent and runs on match, timeout, or explicit cancel.
+ *
+ * @param {object} opts
+ * @param {() => string[]} opts.candidateDirsFn - returns relative dir names
+ *   under claudeProjectsDir. Re-evaluated at rescan time.
+ * @param {Set<string>} opts.snapshot - "<dirName>/<file>" keys to ignore.
+ * @param {number} opts.timeoutMs - final-rescan deadline.
+ * @param {string} opts.claudeProjectsDir - absolute path resolving relative
+ *   names from candidateDirsFn.
+ * @param {(err: Error|null, hit: {dirName: string, file: string, bornAt: number}|null) => void} onResult
+ * @returns {() => void} cancel function (idempotent)
+ */
+function waitForNewJsonl({ candidateDirsFn, snapshot, timeoutMs, claudeProjectsDir }, onResult) {
+  let done = false;
+  const watchers = [];
+  let timer = null;
+
+  const cleanup = () => {
+    if (done) return;
+    done = true;
+    if (timer) { clearTimeout(timer); timer = null; }
+    while (watchers.length) {
+      const w = watchers.pop();
+      try { w.close(); } catch (_) {}
+    }
+  };
+
+  const resolve = (err, hit) => {
+    if (done) return;
+    cleanup();
+    try { onResult(err, hit); } catch (_) {}
+  };
+
+  const tryAcceptFile = (dirName, file) => {
+    if (!file || !file.endsWith('.jsonl')) return false;
+    if (snapshot.has(dirName + '/' + file)) return false;
+    let stat;
+    try { stat = fs.statSync(path.join(claudeProjectsDir, dirName, file)); } catch (_) { return false; }
+    const bornAt = stat.birthtimeMs || stat.mtimeMs;
+    resolve(null, { dirName, file, bornAt });
+    return true;
+  };
+
+  // Register watchers on each candidate dir that exists at call time. Failures
+  // (EMFILE / ENOSPC / ENOENT) silently fall through to the timeout rescan,
+  // which is exactly today's contract.
+  for (const dirName of candidateDirsFn()) {
+    try {
+      const watcher = fs.watch(path.join(claudeProjectsDir, dirName), (event, file) => {
+        if (done || event !== 'rename') return;
+        tryAcceptFile(dirName, file);
+      });
+      if (typeof watcher.on === 'function') {
+        watcher.on('error', () => { /* swallow; rescan will catch */ });
+      }
+      watchers.push(watcher);
+    } catch (_) {
+      // Fall through to rescan
+    }
+  }
+
+  // Final-rescan deadline. Also handles the cold-start case where no
+  // candidate dir existed at call time (the dir gets created during the wait).
+  timer = setTimeout(() => {
+    if (done) return;
+    const fresh = [];
+    for (const dirName of candidateDirsFn()) {
+      let entries;
+      try { entries = fs.readdirSync(path.join(claudeProjectsDir, dirName)); } catch (_) { continue; }
+      for (const f of entries) {
+        if (!f.endsWith('.jsonl')) continue;
+        if (snapshot.has(dirName + '/' + f)) continue;
+        let stat;
+        try { stat = fs.statSync(path.join(claudeProjectsDir, dirName, f)); } catch (_) { continue; }
+        fresh.push({ dirName, file: f, bornAt: stat.birthtimeMs || stat.mtimeMs });
+      }
+    }
+    if (fresh.length === 0) {
+      resolve(null, null);
+      return;
+    }
+    fresh.sort((a, b) => b.bornAt - a.bornAt);
+    resolve(null, fresh[0]);
+  }, timeoutMs);
+
+  return cleanup;
+}
+
+/**
  * Represents a single PTY session with its process, clients, and scrollback.
  */
 class PtySession {
@@ -458,14 +557,13 @@ class PtySessionManager {
 
     console.log(`[PTY] Spawned session ${sessionId} (PID: ${ptyProcess.pid}) cmd: "${fullCommand}" cwd: "${cwd || process.cwd()}"`);
 
-    // ── Async: detect Claude session UUID from newest JSONL after spawn ──
+    // ── Async: detect Claude session UUID from new JSONL after spawn ──
     // Claude Code creates a JSONL file in ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl.
-    // We snapshot the set of existing JSONLs synchronously at spawn time and,
-    // after a short delay, only accept files that did NOT exist pre-spawn.
-    // Without this, any unrelated Claude activity in the same cwd (another
-    // Myrlin session, or a bare `claude` invocation) can bump an older
-    // JSONL's mtime past ours, and we would silently bind this session to
-    // someone else's transcript.
+    // We snapshot the set of existing JSONLs synchronously at spawn time and
+    // hand off to waitForNewJsonl, which fires on fs.watch events and falls
+    // back to a final rescan at t+8s. Snapshot diff prevents binding to a
+    // pre-existing transcript whose mtime drifted; fs.watch makes the binding
+    // sub-second on the happy path.
     if (resolvedCwd && !resumeSessionId) {
       const claudeDir = path.join(os.homedir(), '.claude', 'projects');
       const findCandidateDirs = () => {
@@ -491,46 +589,20 @@ class PtySessionManager {
       const preSnapshot = new Set();
       for (const dirName of findCandidateDirs()) {
         try {
-          const projDir = path.join(claudeDir, dirName);
-          for (const f of fs.readdirSync(projDir)) {
+          for (const f of fs.readdirSync(path.join(claudeDir, dirName))) {
             if (f.endsWith('.jsonl')) preSnapshot.add(dirName + '/' + f);
           }
         } catch (_) {}
       }
 
-      setTimeout(() => {
-        try {
-          const candidates = findCandidateDirs();
-          if (candidates.length === 0) return;
-
-          // Collect only JSONLs that were NOT in the pre-spawn snapshot.
-          // Pre-existing files (whose mtimes may have drifted) are ignored.
-          const fresh = [];
-          for (const dirName of candidates) {
-            const projDir = path.join(claudeDir, dirName);
-            let entries;
-            try { entries = fs.readdirSync(projDir); } catch (_) { continue; }
-            for (const f of entries) {
-              if (!f.endsWith('.jsonl')) continue;
-              if (preSnapshot.has(dirName + '/' + f)) continue;
-              let stat;
-              try { stat = fs.statSync(path.join(projDir, f)); } catch (_) { continue; }
-              // Prefer birthtime (true creation time) when available — that
-              // is the right semantic for "which JSONL did this PTY produce."
-              // Fall back to mtime on filesystems that don't track birthtime
-              // reliably (some older Linux/btrfs/zfs return 0 or mtime).
-              const bornAt = stat.birthtimeMs || stat.mtimeMs;
-              fresh.push({ dirName, name: f, bornAt });
-            }
-          }
-
-          if (fresh.length === 0) {
+      const cancelWatch = waitForNewJsonl(
+        { candidateDirsFn: findCandidateDirs, snapshot: preSnapshot, timeoutMs: 8000, claudeProjectsDir: claudeDir },
+        (err, hit) => {
+          if (err || !hit) {
             console.log(`[PTY] No new JSONL appeared for ${sessionId}; skipping resumeSessionId backfill`);
             return;
           }
-
-          fresh.sort((a, b) => b.bornAt - a.bornAt);
-          const uuid = fresh[0].name.replace('.jsonl', '');
+          const uuid = hit.file.replace('.jsonl', '');
           console.log(`[PTY] Detected Claude session UUID for ${sessionId}: ${uuid}`);
 
           // Save to store so future restarts use --resume <uuid>.
@@ -569,10 +641,9 @@ class PtySessionManager {
               if (ws.readyState === 1) ws.send(backfillMsg);
             } catch (_) {}
           }
-        } catch (err) {
-          console.log(`[PTY] UUID detection failed for ${sessionId}: ${err.message}`);
         }
-      }, 8000); // Wait 8s for Claude to create the JSONL file
+      );
+      session._cancelWatch = cancelWatch;
     }
 
     return session;
@@ -755,6 +826,12 @@ class PtySessionManager {
       session.pingInterval = null;
     }
 
+    // Cancel any in-flight JSONL watcher (idempotent if it already resolved)
+    if (typeof session._cancelWatch === 'function') {
+      try { session._cancelWatch(); } catch (_) {}
+      session._cancelWatch = null;
+    }
+
     // Kill the PTY process
     if (session.alive) {
       try {
@@ -863,4 +940,4 @@ class PtySessionManager {
   }
 }
 
-module.exports = { PtySessionManager };
+module.exports = { PtySessionManager, __test: { waitForNewJsonl } };

--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -528,14 +528,30 @@ class PtySessionManager {
           const uuid = fresh[0].name.replace('.jsonl', '');
           console.log(`[PTY] Detected Claude session UUID for ${sessionId}: ${uuid}`);
 
-          // Save to store so future restarts use --resume <uuid>
+          // Save to store so future restarts use --resume <uuid>.
+          // Defensive: refuse to backfill if another Myrlin session already
+          // owns this UUID. That shouldn't be possible now that the snapshot
+          // diff filters pre-existing JSONLs, but the check is cheap and
+          // prevents two sessions from ever pointing at the same transcript.
+          let backfilled = false;
           try {
             const store = getStore();
-            if (store.getSession(sessionId)) {
+            const conflict = store.getAllSessionsList().find(s =>
+              s.id !== sessionId && s.resumeSessionId === uuid
+            );
+            if (conflict) {
+              console.warn(
+                `[PTY] Refusing to backfill resumeSessionId=${uuid} for session ${sessionId}: ` +
+                `already owned by session ${conflict.id} ("${conflict.name || ''}")`
+              );
+            } else if (store.getSession(sessionId)) {
               store.updateSession(sessionId, { resumeSessionId: uuid });
               console.log(`[PTY] Backfilled resumeSessionId=${uuid} for session ${sessionId}`);
+              backfilled = true;
             }
           } catch (_) {}
+
+          if (!backfilled) return;
 
           // Also store on the session object for layout saves
           session.detectedResumeId = uuid;

--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -195,32 +195,19 @@ class PtySessionManager {
     let fullCommand = command;
     if (resumeSessionId) {
       fullCommand += ' --resume ' + resumeSessionId;
-    } else if (cwd && !newSession) {
-      // Only add --continue when there is actually conversation history for this
-      // working directory. `claude --continue` exits with code 1 ("No conversation
-      // found to continue") on a fresh directory — e.g. a brand-new git worktree.
-      // Scan ~/.claude/projects/ for any JSONL file whose encoded path matches cwd.
-      let hasHistory = false;
-      try {
-        const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-        if (fs.existsSync(claudeDir)) {
-          const normalizedCwd = cwd.replace(/[/\\]/g, path.sep);
-          const match = fs.readdirSync(claudeDir).find(d => {
-            try {
-              return decodeURIComponent(d).replace(/[/\\]/g, path.sep) === normalizedCwd;
-            } catch (_) { return false; }
-          });
-          if (match) {
-            const projDir = path.join(claudeDir, match);
-            hasHistory = fs.readdirSync(projDir).some(f => f.endsWith('.jsonl'));
-          }
-        }
-      } catch (_) { /* filesystem error — fall through, don't add --continue */ }
-      if (hasHistory) {
-        fullCommand += ' --continue';
-      }
-      // If no history, run bare `claude` — starts a fresh session without error.
     }
+    // Otherwise run bare `claude` — start a fresh transcript.
+    //
+    // Auto-`--continue` was previously added whenever the cwd had any prior
+    // Claude history. That silently bound a brand-new Myrlin session to
+    // whichever transcript was most recent in that directory — frequently a
+    // different Myrlin session's, or one from running `claude` directly. The
+    // post-spawn UUID detector then persisted the wrong UUID as resumeSessionId
+    // and the misbinding became permanent.
+    //
+    // Resume is now driven strictly by an explicit resumeSessionId. To
+    // continue a past transcript, use the project panel's "Open in Terminal"
+    // (which sets resumeSessionId), or attach the session via Discover.
     if (bypassPermissions) {
       fullCommand += ' --dangerously-skip-permissions';
     }

--- a/src/web/pty-manager.js
+++ b/src/web/pty-manager.js
@@ -473,17 +473,18 @@ class PtySessionManager {
 
     // ── Async: detect Claude session UUID from newest JSONL after spawn ──
     // Claude Code creates a JSONL file in ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl.
-    // After a short delay, scan for the newest file and backfill resumeSessionId
-    // so future restarts use the precise --resume <uuid> instead of --continue.
+    // We snapshot the set of existing JSONLs synchronously at spawn time and,
+    // after a short delay, only accept files that did NOT exist pre-spawn.
+    // Without this, any unrelated Claude activity in the same cwd (another
+    // Myrlin session, or a bare `claude` invocation) can bump an older
+    // JSONL's mtime past ours, and we would silently bind this session to
+    // someone else's transcript.
     if (resolvedCwd && !resumeSessionId) {
-      setTimeout(() => {
+      const claudeDir = path.join(os.homedir(), '.claude', 'projects');
+      const findCandidateDirs = () => {
         try {
-          const claudeDir = path.join(os.homedir(), '.claude', 'projects');
-          if (!fs.existsSync(claudeDir)) return;
-
-          // Claude encodes the cwd path as a directory name under ~/.claude/projects/
-          // Try multiple encoding patterns: URL-encoded, slash-replaced
-          const candidates = fs.readdirSync(claudeDir).filter(d => {
+          if (!fs.existsSync(claudeDir)) return [];
+          return fs.readdirSync(claudeDir).filter(d => {
             try {
               const decoded = decodeURIComponent(d);
               const normalizedDecoded = decoded.replace(/[/\\]/g, path.sep);
@@ -493,25 +494,51 @@ class PtySessionManager {
               return false;
             }
           });
+        } catch (_) {
+          return [];
+        }
+      };
 
+      // Pre-spawn snapshot of JSONLs that already existed in candidate dirs.
+      // Keys are "<dirName>/<file>" so identical UUIDs in sibling dirs stay distinct.
+      const preSnapshot = new Set();
+      for (const dirName of findCandidateDirs()) {
+        try {
+          const projDir = path.join(claudeDir, dirName);
+          for (const f of fs.readdirSync(projDir)) {
+            if (f.endsWith('.jsonl')) preSnapshot.add(dirName + '/' + f);
+          }
+        } catch (_) {}
+      }
+
+      setTimeout(() => {
+        try {
+          const candidates = findCandidateDirs();
           if (candidates.length === 0) return;
 
-          const projDir = path.join(claudeDir, candidates[0]);
-          const jsonls = fs.readdirSync(projDir)
-            .filter(f => f.endsWith('.jsonl'))
-            .map(f => {
-              try {
-                return { name: f, mtime: fs.statSync(path.join(projDir, f)).mtimeMs };
-              } catch (_) {
-                return null;
-              }
-            })
-            .filter(Boolean)
-            .sort((a, b) => b.mtime - a.mtime);
+          // Collect only JSONLs that were NOT in the pre-spawn snapshot.
+          // Pre-existing files (whose mtimes may have drifted) are ignored.
+          const fresh = [];
+          for (const dirName of candidates) {
+            const projDir = path.join(claudeDir, dirName);
+            let entries;
+            try { entries = fs.readdirSync(projDir); } catch (_) { continue; }
+            for (const f of entries) {
+              if (!f.endsWith('.jsonl')) continue;
+              if (preSnapshot.has(dirName + '/' + f)) continue;
+              let stat;
+              try { stat = fs.statSync(path.join(projDir, f)); } catch (_) { continue; }
+              fresh.push({ dirName, name: f, mtime: stat.mtimeMs });
+            }
+          }
 
-          if (jsonls.length === 0) return;
+          if (fresh.length === 0) {
+            console.log(`[PTY] No new JSONL appeared for ${sessionId}; skipping resumeSessionId backfill`);
+            return;
+          }
 
-          const uuid = jsonls[0].name.replace('.jsonl', '');
+          fresh.sort((a, b) => b.mtime - a.mtime);
+          const uuid = fresh[0].name.replace('.jsonl', '');
           console.log(`[PTY] Detected Claude session UUID for ${sessionId}: ${uuid}`);
 
           // Save to store so future restarts use --resume <uuid>

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -7231,7 +7231,7 @@ class CWMApp {
   _findProjectSession(sessionId) {
     for (const project of (this.state.projects || [])) {
       for (const s of (project.sessions || [])) {
-        if (s.name === sessionId) {
+        if (s.claudeSessionId === sessionId) {
           return { workingDir: project.realPath || '', workspaceId: this.state.activeWorkspace ? this.state.activeWorkspace.id : null };
         }
       }
@@ -7292,7 +7292,7 @@ class CWMApp {
         ].filter(Boolean).join(' ');
 
         const latestSession = p.sessions && p.sessions.length > 0 ? p.sessions[0] : null;
-        const latestSessionId = latestSession ? latestSession.name : '';
+        const latestSessionId = latestSession ? latestSession.claudeSessionId : '';
         const latestSessionTitle = latestSession ? (latestSession.title || '') : '';
         return `<div class="discover-row" data-path="${this.escapeHtml(p.realPath)}" data-name="${this.escapeHtml(name)}" data-session-id="${this.escapeHtml(latestSessionId)}" data-session-title="${this.escapeHtml(latestSessionTitle)}">
           <div class="discover-check">
@@ -8740,7 +8740,7 @@ class CWMApp {
       const sessionSizeMap = {};
       (this.state.projects || []).forEach(p => {
         (p.sessions || []).forEach(ps => {
-          if (ps.size) sessionSizeMap[ps.name] = ps.size;
+          if (ps.size) sessionSizeMap[ps.claudeSessionId] = ps.size;
         });
       });
 
@@ -9619,7 +9619,7 @@ class CWMApp {
         if (name.toLowerCase().includes(query) || encoded.toLowerCase().includes(query) || path.toLowerCase().includes(query)) return true;
         // Match against any session ID, title, or Claude custom-title within this project
         const allSessions = p.sessions || [];
-        return allSessions.some(s => (s.name || '').toLowerCase().includes(query) || (s.title || '').toLowerCase().includes(query));
+        return allSessions.some(s => (s.claudeSessionId || '').toLowerCase().includes(query) || (s.title || '').toLowerCase().includes(query));
       });
     }
 
@@ -9638,7 +9638,7 @@ class CWMApp {
       const sizeStr = p.totalSize ? this.formatSize(p.totalSize) : '';
       const allSessions = p.sessions || [];
       // Filter out hidden project sessions (unless showHidden is on)
-      let sessions = allSessions.filter(s => this.state.showHidden || !this.state.hiddenProjectSessions.has(s.name));
+      let sessions = allSessions.filter(s => this.state.showHidden || !this.state.hiddenProjectSessions.has(s.claudeSessionId));
 
       // When search is active, also filter individual sessions by query
       if (query) {
@@ -9649,9 +9649,9 @@ class CWMApp {
         // If the project itself doesn't match, only show sessions that match
         if (!projectMatches) {
           sessions = sessions.filter(s => {
-            const sName = (s.name || '').toLowerCase();
+            const sName = (s.claudeSessionId || '').toLowerCase();
             const sClaudeTitle = (s.title || '').toLowerCase();
-            const sTitle = (this.getProjectSessionTitle(s.name) || '').toLowerCase();
+            const sTitle = (this.getProjectSessionTitle(s.claudeSessionId) || '').toLowerCase();
             return sName.includes(query) || sClaudeTitle.includes(query) || sTitle.includes(query);
           });
         }
@@ -9659,7 +9659,7 @@ class CWMApp {
 
       // Build session sub-items
       const sessionItems = sessions.map(s => {
-        const sessName = s.name || 'unnamed';
+        const sessName = s.claudeSessionId || 'unnamed';
         const claudeTitle = s.title || null;
         if (claudeTitle && !this.getProjectSessionTitle(sessName)) {
           const titles = JSON.parse(localStorage.getItem('cwm_projectSessionTitles') || '{}');

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -3509,10 +3509,21 @@ class CWMApp {
     // Check localStorage first
     const titles = JSON.parse(localStorage.getItem('cwm_projectSessionTitles') || '{}');
     if (titles[claudeSessionId]) return titles[claudeSessionId];
-    // Fall back: check if any workspace session with this resumeSessionId has a name
+    // Fall back: check workspace sessions linked by resumeSessionId.
+    // If two sessions share the same UUID (a leftover from older buggy
+    // backfills), `find()` would return whichever came first in iteration
+    // order and label the JSONL with the wrong session's name. Collect all
+    // links, ignore the result if it's ambiguous, and otherwise pick the
+    // most-recently-active one for stable display.
     const allSessions = this.state.allSessions || this.state.sessions || [];
-    const linked = allSessions.find(s => s.resumeSessionId === claudeSessionId && s.name);
-    return linked ? linked.name : null;
+    const linked = allSessions.filter(s => s.resumeSessionId === claudeSessionId && s.name);
+    if (linked.length === 0) return null;
+    if (linked.length > 1) {
+      const ids = linked.map(s => s.id).join(', ');
+      console.warn(`[CWM] Claude UUID ${claudeSessionId} is linked by ${linked.length} sessions (${ids}); not displaying a name fallback`);
+      return null;
+    }
+    return linked[0].name;
   }
 
   /**

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -1679,7 +1679,7 @@ app.get('/api/discover', requireAuth, (req, res) => {
         sessionCount: sessionFiles.length,
         totalSize,
         lastActive: sessionFiles.length > 0 ? sessionFiles[0].modified : null,
-        sessions: sessionFiles.map(s => ({ name: s.name, modified: s.modified, size: s.size, title: sessionTitles[s.name] || null })),
+        sessions: sessionFiles.map(s => ({ claudeSessionId: s.name, modified: s.modified, size: s.size, title: sessionTitles[s.name] || null })),
       });
     }
 

--- a/test/pty-watcher.test.js
+++ b/test/pty-watcher.test.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Tests for the waitForNewJsonl hybrid watcher in src/web/pty-manager.js.
+ *
+ * Run standalone: node test/pty-watcher.test.js
+ *
+ * The helper is exported via the pty-manager module's __test exports. The
+ * tests use a temp directory and short timeouts (200-500 ms) instead of the
+ * production 8 s budget so the suite finishes in a few seconds.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Skip node-pty's runtime helper checks — we don't spawn anything here.
+process.env.PTY_SKIP_HELPER_FIX = '1';
+
+const { __test } = require('../src/web/pty-manager');
+const { waitForNewJsonl } = __test;
+
+let passed = 0;
+let failed = 0;
+
+function log(ok, name, err) {
+  if (ok) {
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } else {
+    failed++;
+    console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+    if (err) console.log(`    \x1b[31m${err.message || err}\x1b[0m`);
+  }
+}
+
+async function run(name, fn) {
+  try {
+    await fn();
+    log(true, name);
+  } catch (err) {
+    log(false, name, err);
+  }
+}
+
+function makeTmpProjects() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cwm-watch-'));
+  const dirName = 'projA';
+  fs.mkdirSync(path.join(tmp, dirName));
+  return { tmp, dirName };
+}
+
+function rmrf(p) {
+  try { fs.rmSync(p, { recursive: true, force: true }); } catch (_) {}
+}
+
+function waitFor({ candidateDirsFn, snapshot, timeoutMs, claudeProjectsDir }) {
+  return new Promise(resolve => {
+    waitForNewJsonl(
+      { candidateDirsFn, snapshot, timeoutMs, claudeProjectsDir },
+      (err, hit) => resolve({ err, hit })
+    );
+  });
+}
+
+(async () => {
+  console.log('\n  \x1b[1mwaitForNewJsonl\x1b[0m');
+
+  await run('matches a new .jsonl file written during the wait', async () => {
+    const { tmp, dirName } = makeTmpProjects();
+    try {
+      const pending = waitFor({
+        candidateDirsFn: () => [dirName],
+        snapshot: new Set(),
+        timeoutMs: 1500,
+        claudeProjectsDir: tmp,
+      });
+      // Give fs.watch a moment to register before we write
+      setTimeout(() => fs.writeFileSync(path.join(tmp, dirName, 'aaa.jsonl'), ''), 80);
+      const start = Date.now();
+      const { err, hit } = await pending;
+      const elapsed = Date.now() - start;
+      if (err) throw err;
+      if (!hit) throw new Error('expected a hit, got null');
+      if (hit.file !== 'aaa.jsonl') throw new Error('wrong file: ' + hit.file);
+      if (hit.dirName !== dirName) throw new Error('wrong dirName: ' + hit.dirName);
+      if (elapsed > 1000) throw new Error('took too long: ' + elapsed + 'ms (fs.watch should fire fast)');
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  await run('returns null on timeout when nothing appears', async () => {
+    const { tmp, dirName } = makeTmpProjects();
+    try {
+      const start = Date.now();
+      const { err, hit } = await waitFor({
+        candidateDirsFn: () => [dirName],
+        snapshot: new Set(),
+        timeoutMs: 250,
+        claudeProjectsDir: tmp,
+      });
+      const elapsed = Date.now() - start;
+      if (err) throw err;
+      if (hit !== null) throw new Error('expected null, got ' + JSON.stringify(hit));
+      if (elapsed < 200) throw new Error('returned too early: ' + elapsed + 'ms');
+      if (elapsed > 600) throw new Error('returned too late: ' + elapsed + 'ms');
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  await run('ignores files already in the snapshot', async () => {
+    const { tmp, dirName } = makeTmpProjects();
+    try {
+      // Pre-create a file and add it to the snapshot
+      fs.writeFileSync(path.join(tmp, dirName, 'old.jsonl'), '');
+      const snapshot = new Set([dirName + '/old.jsonl']);
+      const pending = waitFor({
+        candidateDirsFn: () => [dirName],
+        snapshot,
+        timeoutMs: 350,
+        claudeProjectsDir: tmp,
+      });
+      // Touching the existing file (re-writing it) must NOT trigger a match.
+      // fs.watch fires 'change' for content rewrites; on some platforms it
+      // also fires 'rename' for file replacement. Either way the snapshot
+      // filter must reject it.
+      setTimeout(() => fs.writeFileSync(path.join(tmp, dirName, 'old.jsonl'), 'updated'), 50);
+      const { err, hit } = await pending;
+      if (err) throw err;
+      if (hit !== null) throw new Error('expected null but got hit: ' + JSON.stringify(hit));
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  await run('cold-start: candidate dir does not exist at call time, gets created during wait', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cwm-watch-cold-'));
+    const dirName = 'projLate';
+    try {
+      const pending = waitFor({
+        candidateDirsFn: () => {
+          // Only return the dir name once it actually exists on disk
+          try { fs.statSync(path.join(tmp, dirName)); return [dirName]; }
+          catch (_) { return []; }
+        },
+        snapshot: new Set(),
+        timeoutMs: 800,
+        claudeProjectsDir: tmp,
+      });
+      // Create the dir + file after the helper has already started
+      setTimeout(() => {
+        fs.mkdirSync(path.join(tmp, dirName));
+        fs.writeFileSync(path.join(tmp, dirName, 'late.jsonl'), '');
+      }, 100);
+      const { err, hit } = await pending;
+      if (err) throw err;
+      if (!hit) throw new Error('expected a hit (rescan should catch it), got null');
+      if (hit.file !== 'late.jsonl') throw new Error('wrong file: ' + hit.file);
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  await run('cancel() before the wait finishes: callback is not invoked', async () => {
+    const { tmp, dirName } = makeTmpProjects();
+    try {
+      let resolvedWith = 'never';
+      const cancel = waitForNewJsonl(
+        {
+          candidateDirsFn: () => [dirName],
+          snapshot: new Set(),
+          timeoutMs: 500,
+          claudeProjectsDir: tmp,
+        },
+        (err, hit) => { resolvedWith = { err, hit }; }
+      );
+      cancel();
+      // Give it well past the timeout to make sure no callback fires
+      await new Promise(r => setTimeout(r, 700));
+      // Even if a file appears late, callback must not run
+      fs.writeFileSync(path.join(tmp, dirName, 'late.jsonl'), '');
+      await new Promise(r => setTimeout(r, 100));
+      if (resolvedWith !== 'never') throw new Error('callback fired after cancel: ' + JSON.stringify(resolvedWith));
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  await run('rescan picks freshest by birthtime when watcher missed events', async () => {
+    const { tmp, dirName } = makeTmpProjects();
+    try {
+      // Pre-create two files that didn't exist at "spawn" but pretend the
+      // watcher missed both. We achieve this by passing a snapshot that
+      // doesn't include them, AND not using fs.watch (call helper after
+      // files exist so the watcher registers but no events fire).
+      fs.writeFileSync(path.join(tmp, dirName, 'one.jsonl'), '');
+      // Brief delay so birthtimes differ
+      await new Promise(r => setTimeout(r, 30));
+      fs.writeFileSync(path.join(tmp, dirName, 'two.jsonl'), '');
+
+      const { err, hit } = await waitFor({
+        candidateDirsFn: () => [dirName],
+        snapshot: new Set(),
+        timeoutMs: 200,
+        claudeProjectsDir: tmp,
+      });
+      if (err) throw err;
+      if (!hit) throw new Error('expected a hit, got null');
+      if (hit.file !== 'two.jsonl') throw new Error('expected freshest "two.jsonl", got ' + hit.file);
+    } finally {
+      rmrf(tmp);
+    }
+  });
+
+  console.log('\n  ' + '─'.repeat(42));
+  console.log(`  \x1b[1mResults:\x1b[0m ${passed} passed, ${failed} failed, ${passed + failed} total`);
+  console.log('  ' + '─'.repeat(42) + '\n');
+  process.exit(failed > 0 ? 1 : 0);
+})().catch(err => {
+  console.error('Unhandled error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

A Myrlin session could silently bind to a different Claude transcript than its name implied. Two cooperating flaws in `pty-manager.js`:

1. When no `resumeSessionId` was set, bare spawns added `claude --continue` whenever the cwd's project dir contained any `.jsonl`. The `hasHistory` check only avoided the exit-code-1 error on fresh dirs — it did not check whose transcript that history belonged to. So a new Myrlin session in a busy cwd resumed whichever transcript Claude considered most recent (often a sibling Myrlin session's, or one from a bare `claude` run).
2. The post-spawn detector picked the JSONL with the newest `mtime` and persisted it as `resumeSessionId`, with no ownership check. Once (1) bumped a sibling's mtime, the wrong UUID stuck permanently — the detector ran only once, so it never self-corrected.

## Changes

- **`pty-manager.js`** — drop the `--continue` path entirely; resume is only via an explicit `resumeSessionId`. Detector now takes a pre-spawn JSONL snapshot and only accepts files born after spawn, with `birthtimeMs` as the tiebreak. Detection is hybrid: `fs.watch` resolves sub-second on the happy path; a t+8 s rescan covers macOS FSEvents drops and cold-start cwds. Watcher cleanup is tied to `killSession` (no fd leaks). Defensive guard refuses to backfill a UUID already owned by another session.
- **`server.js` + `app.js`** — rename project-panel field `name` → `claudeSessionId` (it always held a UUID; the misnaming was a footgun). Seven consumer sites updated.
- **`app.js#getProjectSessionTitle`** — when two sessions share a `resumeSessionId`, warn and return `null` instead of returning `find()`'s first hit.
- **`test/pty-watcher.test.js`** — 6 new async tests for the watcher (watch path, timeout, snapshot exclusion, cold-start, cancel, rescan tiebreak). Existing 58-test suite unchanged.
