### PR TITLE
feat: cross-tab session pips, navigation, and tab positional colors (issue #59)

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -148,6 +148,7 @@ class CWMApp {
     // Key: groupId, Value: { panes: [TerminalPane|null x MAX_PANES], domFragments: [DocumentFragment|null x MAX_PANES] }
     this._groupPaneCache = {};
     this.PANE_SLOT_COLORS = ['mauve', 'blue', 'green', 'peach', 'red', 'pink'];
+    this.TAB_COLORS = (window.InstanceColors && window.InstanceColors.TAB_COLORS) || [];
     this._gridColSizes = [1, 1];  // fr ratios for column widths
     this._gridRowSizes = [1, 1];  // fr ratios for row heights
     // Voice recognition instances per slot (for mic-to-terminal input)
@@ -4148,14 +4149,45 @@ class CWMApp {
     });
   }
 
-  /** Find which pane slot (0-3) a session is open in, or -1 if not found */
-  getSlotForSession(sessionId) {
-    for (let i = 0; i < this.terminalPanes.length; i++) {
-      if (this.terminalPanes[i] && this.terminalPanes[i].sessionId === sessionId) {
-        return i;
-      }
-    }
-    return -1;
+  /** Return one entry per place a session is open across all tab groups. */
+  getSessionInstances(sessionId) {
+    return window.InstanceColors.getSessionInstances(sessionId, this._tabGroups || []);
+  }
+
+  /** Return the (positional) colour for a tab — global index across all tabs. */
+  getTabColor(tabId) {
+    return window.InstanceColors.getTabColor(tabId, this._tabGroups || []);
+  }
+
+  /** Render one indicator: top half = tab colour, bottom half = slot colour, 1px divider. */
+  renderInstanceIndicator({ tabColor, slotColor, title }) {
+    return `<span class="instance-indicator"
+      title="${this.escapeHtml(title || '')}"
+      style="--c-outer:var(--${tabColor});
+             --c-inner:var(--${slotColor})">
+      <span class="instance-indicator-inner"></span>
+    </span>`;
+  }
+
+  /** Render the full row of indicators for a session, or empty string. */
+  renderInstanceIndicatorRow(sessionId) {
+    if (!this.state.settings.paneColorHighlights) return '';
+    const instances = this.getSessionInstances(sessionId);
+    if (!instances.length) return '';
+    return `<span class="instance-indicator-row">${
+      instances.map(inst => this.renderInstanceIndicator({
+        tabColor:  this.getTabColor(inst.tabId),
+        slotColor: this.PANE_SLOT_COLORS[inst.slot % this.PANE_SLOT_COLORS.length],
+        title:     this._formatInstanceTooltip(inst),
+      })).join('')
+    }</span>`;
+  }
+
+  /** Build a textual tooltip for an instance: "<tab> › slot N". */
+  _formatInstanceTooltip({ tabId, slot }) {
+    const tab = (this._tabGroups || []).find(g => g.id === tabId);
+    const tabName = tab ? tab.name : '?';
+    return `${tabName} › slot ${slot + 1}`;
   }
 
   /** Open the settings overlay */
@@ -8862,11 +8894,8 @@ class CWMApp {
           }
         }
 
-        // Pane color pip — show matching dot if session is open in a terminal slot
-        const slotIdx = this.getSlotForSession(s.id);
-        const pip = (slotIdx !== -1 && this.state.settings.paneColorHighlights)
-          ? `<span class="pane-color-pip" style="background:var(--${this.PANE_SLOT_COLORS[slotIdx]})"></span>`
-          : '';
+        // Three-layer indicator — one per place this session is open across all tab groups
+        const pip = this.renderInstanceIndicatorRow(s.id);
 
         // Build meta row (badges + size + time) — only if there's something to show
         const metaParts = [badges, sizeStr ? `<span class="ws-session-size">${sizeStr}</span>` : ''].filter(Boolean).join('');
@@ -8874,8 +8903,8 @@ class CWMApp {
         const timeEl = timeStr ? `<span class="ws-session-time">${timeStr}</span>` : '';
 
         return `<div class="ws-session-item${isHidden ? ' ws-session-hidden' : ''}" data-session-id="${s.id}" draggable="true" title="${this.escapeHtml(s.workingDir || '')}">
-          <span class="ws-session-dot${tristateAttr}" style="background: ${statusDot}"></span>${pip}
-          <span class="ws-session-name">${this.escapeHtml(name)}</span>${timeEl}
+          <span class="ws-session-dot${tristateAttr}" style="background: ${statusDot}"></span>
+          <span class="ws-session-name">${this.escapeHtml(name)}</span>${pip}${timeEl}
           ${metaRow}
         </div>`;
       };
@@ -10543,13 +10572,12 @@ class CWMApp {
       this.switchTerminalTab(slotIdx);
     }
 
-    // Re-render sidebar to show pane color pips
-    if (this.state.settings.paneColorHighlights) {
-      this.renderWorkspaces();
-    }
-
     // Refresh pinned-notes badge for this pane now that a session is loaded
     this._refreshPanePin(slotIdx);
+
+    // Route through the centralised chokepoint so the sidebar indicator and
+    // server-persisted layout reflect the new pane.
+    this.saveTerminalLayout();
   }
 
   /**
@@ -11025,14 +11053,13 @@ class CWMApp {
       this.updateTerminalTabs();
     }
 
-    // Re-render sidebar to remove pane color pips
-    if (this.state.settings.paneColorHighlights) {
-      this.renderWorkspaces();
-    }
-
     if (sessionName) {
       this.showToast(`"${sessionName}" moved to background - drag it back to reconnect`, 'info');
     }
+
+    // Route through the centralised chokepoint so the sidebar indicator and
+    // server-persisted layout reflect the closed pane.
+    this.saveTerminalLayout();
   }
 
   /**
@@ -11360,6 +11387,10 @@ class CWMApp {
         if (tp) tp.safeFit();
       });
     });
+
+    // Route through the centralised chokepoint so the sidebar indicator and
+    // server-persisted layout reflect the swapped panes.
+    this.saveTerminalLayout();
   }
 
   updateTerminalGridLayout() {
@@ -13413,7 +13444,10 @@ class CWMApp {
       const tp = this.terminalPanes.find((_, i) => p.slot === i);
       return tp !== null;
     });
-    return `<button class="terminal-group-tab${isActive ? ' active' : ''}" data-group-id="${g.id}">
+    const tabColor = this.getTabColor(g.id);
+    return `<button class="terminal-group-tab${isActive ? ' active' : ''}"
+      data-group-id="${g.id}"
+      style="--tab-color:var(--${tabColor})">
       <span class="terminal-group-tab-dot${hasActive ? '' : ' inactive'}"></span>
       <span class="terminal-group-tab-name">${this.escapeHtml(g.name)}</span>
       ${paneCount > 0 ? `<span class="terminal-group-tab-count">${paneCount}</span>` : ''}
@@ -14351,7 +14385,24 @@ class CWMApp {
     });
   }
 
+  /**
+   * Central chokepoint for tab/pane mutations. Performs three things in order:
+   *   1. Synchronously flushes live pane state via `saveCurrentGroupPanes()`.
+   *   2. Synchronously re-renders the sidebar via `renderWorkspaces()`.
+   *   3. Schedules a debounced (500ms) PUT to /api/layout for server persistence.
+   * Callers that mutate `terminalPanes` or `_tabGroups` should route through
+   * this method rather than calling `renderWorkspaces()` themselves. Note:
+   * `renderWorkspaces()` does not feed back into `saveTerminalLayout()`, so
+   * there is no recursion.
+   */
   saveTerminalLayout() {
+    // Flush live pane state into _tabGroups[*].panes synchronously so the
+    // sidebar indicator (which reads from _tabGroups) is fresh — the
+    // server PUT below stays debounced.
+    this.saveCurrentGroupPanes();
+    if (typeof this.renderWorkspaces === 'function') {
+      this.renderWorkspaces();
+    }
     clearTimeout(this._layoutSaveTimer);
     this._layoutSaveTimer = setTimeout(async () => {
       this.saveCurrentGroupPanes();

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1422,6 +1422,14 @@ class CWMApp {
         return;
       }
 
+      // Pip click — navigate to that instance (handled BEFORE session-item click).
+      const pip = e.target.closest('.instance-indicator');
+      if (pip && pip.dataset.tabId) {
+        e.stopPropagation();
+        this._navigateToInstance(pip.dataset.tabId, parseInt(pip.dataset.slot, 10));
+        return;
+      }
+
       const wsSessionItem = e.target.closest('.ws-session-item');
       if (wsSessionItem) {
         e.stopPropagation();
@@ -4160,12 +4168,16 @@ class CWMApp {
   }
 
   /** Render one indicator: top half = tab colour, bottom half = slot colour, 1px divider. */
-  renderInstanceIndicator({ tabColor, slotColor, title }) {
+  renderInstanceIndicator({ tabColor, slotColor, title, tabId, slot }) {
     return `<span class="instance-indicator"
       title="${this.escapeHtml(title || '')}"
+      data-tab-id="${this.escapeHtml(tabId)}"
+      data-slot="${slot}"
       style="--c-outer:var(--${tabColor});
              --c-inner:var(--${slotColor})">
-      <span class="instance-indicator-inner"></span>
+      <span class="instance-indicator-square">
+        <span class="instance-indicator-inner"></span>
+      </span>
     </span>`;
   }
 
@@ -4179,6 +4191,8 @@ class CWMApp {
         tabColor:  this.getTabColor(inst.tabId),
         slotColor: this.PANE_SLOT_COLORS[inst.slot % this.PANE_SLOT_COLORS.length],
         title:     this._formatInstanceTooltip(inst),
+        tabId:     inst.tabId,
+        slot:      inst.slot,
       })).join('')
     }</span>`;
   }
@@ -4188,6 +4202,23 @@ class CWMApp {
     const tab = (this._tabGroups || []).find(g => g.id === tabId);
     const tabName = tab ? tab.name : '?';
     return `${tabName} › slot ${slot + 1}`;
+  }
+
+  /** Navigate to a session instance: switch to its tab, then briefly pulse the pane. */
+  _navigateToInstance(tabId, slot) {
+    if (this._activeGroupId !== tabId) {
+      this.switchTerminalGroup(tabId);
+    }
+    // Pulse the target pane on the next frame so the switch has rendered.
+    requestAnimationFrame(() => {
+      const paneEls = document.querySelectorAll('.terminal-pane');
+      const paneEl = paneEls[slot];
+      if (!paneEl) return;
+      paneEl.classList.remove('pane-nav-pulse');
+      void paneEl.offsetWidth;                 // force reflow so the animation restarts
+      paneEl.classList.add('pane-nav-pulse');
+      setTimeout(() => paneEl.classList.remove('pane-nav-pulse'), 800);
+    });
   }
 
   /** Open the settings overlay */

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1749,6 +1749,7 @@
   <script src="vendor/xterm-addon-fit/xterm-addon-fit.min.js"></script>
   <script src="vendor/xterm-addon-web-links/xterm-addon-web-links.min.js"></script>
   <script src="terminal.js"></script>
+  <script src="instance-colors.js"></script>
   <script src="app.js"></script>
   <script src="schedules.js"></script>
   <script>

--- a/src/web/public/instance-colors.js
+++ b/src/web/public/instance-colors.js
@@ -1,0 +1,49 @@
+/* ═══════════════════════════════════════════════════════════════
+   Instance-color helpers for the session indicator.
+   Pure functions over tab data; no DOM dependencies.
+   Loaded as a browser <script> AND requireable from Node tests.
+   SPDX-License-Identifier: AGPL-3.0-only
+   ═══════════════════════════════════════════════════════════════ */
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.InstanceColors = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const TAB_COLORS = ['red', 'yellow', 'green', 'teal', 'blue', 'mauve'];
+
+  /**
+   * Return one entry per place sessionId is currently open across all tab groups.
+   * @param {string} sessionId
+   * @param {Array<{id:string, panes:Array<{slot:number,sessionId:string}>}>} tabGroups
+   * @returns {Array<{tabId:string, slot:number}>}
+   */
+  function getSessionInstances(sessionId, tabGroups) {
+    const out = [];
+    if (!sessionId || !Array.isArray(tabGroups)) return out;
+    for (const tab of tabGroups) {
+      const panes = (tab && tab.panes) || [];
+      for (const p of panes) {
+        if (p && p.sessionId === sessionId) {
+          out.push({ tabId: tab.id, slot: p.slot });
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Return the tab's positional colour. Index is the tab's global position
+   * across all tab groups (regardless of folder), wrapping modulo the palette.
+   */
+  function getTabColor(tabId, tabGroups) {
+    const idx = (tabGroups || []).findIndex(g => g.id === tabId);
+    return TAB_COLORS[(idx >= 0 ? idx : 0) % TAB_COLORS.length];
+  }
+
+  return { TAB_COLORS, getSessionInstances, getTabColor };
+});

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -5200,20 +5200,36 @@ html.pane-colors-enabled .terminal-pane:not(.terminal-pane-empty)[data-slot="5"]
 /* ─── Sidebar Session Instance Indicator ───────────────── */
 .instance-indicator-row {
   display: inline-flex;
-  gap: 2px;
+  gap: 0;                /* per-pip 2px padding provides spacing */
   margin-left: 4px;
   flex-shrink: 0;
 }
 .instance-indicator {
+  padding: 2px;          /* invisible 2px hit-area extension; also growth room */
+  cursor: pointer;
+  display: inline-block;
+  line-height: 0;
+  flex-shrink: 0;
+}
+.instance-indicator-square {
   width: 10px;
   height: 10px;
   border-radius: 1px;
   background: var(--c-outer);
-  display: inline-block;
   position: relative;
-  flex-shrink: 0;
   overflow: hidden;
+  display: inline-block;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  transform-origin: center center;
 }
+.instance-indicator:hover .instance-indicator-square {
+  transform: scale(1.1);
+}
+/* Hover ring around the visible square — disabled for now.
+.instance-indicator:hover .instance-indicator-square {
+  box-shadow: 0 0 0 1.5px var(--c-outer);
+}
+*/
 .instance-indicator-inner {
   position: absolute;
   left: 0;
@@ -5226,6 +5242,20 @@ html.pane-colors-enabled .terminal-pane:not(.terminal-pane-empty)[data-slot="5"]
 }
 html:not(.pane-colors-enabled) .instance-indicator-row {
   display: none;
+}
+
+/* Pane pulse — short flash when navigating from a sidebar pip */
+@keyframes pane-nav-pulse {
+  0%   { background-color: rgba(205, 214, 244, 0.05); box-shadow: inset 0 0 0 3px var(--text), 0 0 16px rgba(205, 214, 244, 0.4); }
+  100% { background-color: transparent; box-shadow: inset 0 0 0 0 transparent, 0 0 0 transparent; }
+}
+.pane-nav-pulse::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  animation: pane-nav-pulse 700ms ease-out forwards;
 }
 
 /* ─── Tri-State Dots (Worktree Tasks) ─────────────────── */
@@ -5492,7 +5522,7 @@ html.activity-indicators-disabled .terminal-pane-activity {
   transform: translateX(-50%);
   width: 85%;
   height: 2px;
-  border-radius: 1px;
+  border-radius: 2px;
   background: var(--tab-color);
   pointer-events: none;
 }

--- a/src/web/public/styles.css
+++ b/src/web/public/styles.css
@@ -1290,7 +1290,7 @@ textarea.input {
   flex-wrap: wrap;
   align-items: center;
   gap: 4px 6px;
-  padding: 5px 10px 5px 34px;
+  padding: 5px 10px 5px 24px;
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background var(--transition-fast);
@@ -5197,16 +5197,34 @@ html.pane-colors-enabled .terminal-pane:not(.terminal-pane-empty)[data-slot="5"]
   border-left: 3px solid var(--pink);
 }
 
-/* ─── Sidebar Pane Color Pip ───────────────────────────── */
-.pane-color-pip {
-  display: inline-block;
-  width: 4px;
-  height: 4px;
-  border-radius: 50%;
+/* ─── Sidebar Session Instance Indicator ───────────────── */
+.instance-indicator-row {
+  display: inline-flex;
+  gap: 2px;
+  margin-left: 4px;
   flex-shrink: 0;
-  margin-left: 2px;
 }
-html:not(.pane-colors-enabled) .pane-color-pip {
+.instance-indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 1px;
+  background: var(--c-outer);
+  display: inline-block;
+  position: relative;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.instance-indicator-inner {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 7px;
+  background: var(--c-inner);
+  border-top: 1px solid #000;
+  box-sizing: border-box;
+}
+html:not(.pane-colors-enabled) .instance-indicator-row {
   display: none;
 }
 
@@ -5461,9 +5479,22 @@ html.activity-indicators-disabled .terminal-pane-activity {
   transition: all var(--transition-fast);
   position: relative;
   /* Touch: let DragDropTouch polyfill handle long-press-to-drag without the
-     browser claiming the gesture for the scrollable tab strip. 
+     browser claiming the gesture for the scrollable tab strip.
   */
   touch-action: none;
+}
+
+.terminal-group-tab::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: 2px;
+  transform: translateX(-50%);
+  width: 85%;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--tab-color);
+  pointer-events: none;
 }
 
 .terminal-group-tab:hover {
@@ -5480,12 +5511,16 @@ html.activity-indicators-disabled .terminal-pane-activity {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--green);
+  background: var(--tab-color);
   flex-shrink: 0;
 }
 
 .terminal-group-tab-dot.inactive {
-  background: var(--surface2);
+  opacity: 0.4;
+}
+
+.terminal-group-tab-name {
+  color: var(--tab-color);
 }
 
 .terminal-group-tab-count {

--- a/test/instance-colors.test.js
+++ b/test/instance-colors.test.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for instance-colors UMD module.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const path = require('path');
+const {
+  TAB_COLORS,
+  getSessionInstances,
+  getTabColor,
+} = require(path.join(__dirname, '..', 'src', 'web', 'public', 'instance-colors.js'));
+
+let passed = 0, failed = 0;
+function check(name, ok, detail) {
+  if (ok) { passed++; console.log('  PASS  ' + name); }
+  else    { failed++; console.log('  FAIL  ' + name + (detail ? '  — ' + detail : '')); }
+}
+function eq(a, b) { return JSON.stringify(a) === JSON.stringify(b); }
+
+// Fixture — folderIds preserved on tabs to confirm they don't influence tab color.
+const tabs = [
+  { id: 't1', name: 'Main',    folderId: 'f1', panes: [
+    { slot: 0, sessionId: 'sA' }, { slot: 1, sessionId: 'sB' },
+  ]},
+  { id: 't2', name: 'Logs',    folderId: 'f1', panes: [
+    { slot: 0, sessionId: 'sA' },
+  ]},
+  { id: 't3', name: 'Sandbox', folderId: 'f2', panes: [
+    { slot: 0, sessionId: 'sA' },
+  ]},
+  { id: 't4', name: 'Loose',   folderId: null, panes: [
+    { slot: 2, sessionId: 'sA' },
+  ]},
+  { id: 't5', name: 'Other',   folderId: null, panes: [] },
+];
+
+// 1. TAB_COLORS contract
+check('TAB_COLORS has 6 distinct entries',
+  TAB_COLORS.length === 6 && new Set(TAB_COLORS).size === 6);
+
+// 2. getSessionInstances finds all instances across all tabs
+const instances = getSessionInstances('sA', tabs);
+check('getSessionInstances returns 4 entries for sA',
+  instances.length === 4,
+  'got ' + instances.length);
+check('getSessionInstances entries carry tabId and slot only',
+  instances.every(i => 'tabId' in i && 'slot' in i && !('folderId' in i)));
+check('getSessionInstances finds the ungrouped tab too',
+  instances.some(i => i.tabId === 't4' && i.slot === 2));
+check('getSessionInstances returns empty for unknown session',
+  eq(getSessionInstances('nope', tabs), []));
+
+// 3. getTabColor: GLOBAL positional index across all tabs (folder is irrelevant)
+// Global order: [t1, t2, t3, t4, t5] -> red, yellow, green, teal, blue
+check('getTabColor t1 (global index 0)', getTabColor('t1', tabs) === 'red');
+check('getTabColor t2 (global index 1)', getTabColor('t2', tabs) === 'yellow');
+check('getTabColor t3 (global index 2)', getTabColor('t3', tabs) === 'green');
+check('getTabColor t4 (global index 3)', getTabColor('t4', tabs) === 'teal');
+check('getTabColor t5 (global index 4)', getTabColor('t5', tabs) === 'blue');
+
+// 4. Modulo wraparound at the global level
+const longTabs = Array.from({ length: 8 }, (_, i) => ({
+  id: 'tw' + i, name: 'T' + i, folderId: null, panes: [],
+}));
+check('getTabColor wraps at global index 6', getTabColor('tw6', longTabs) === 'red');
+check('getTabColor wraps at global index 7', getTabColor('tw7', longTabs) === 'yellow');
+
+// 5. Unknown tab falls back to first colour
+check('getTabColor unknown tab falls back to first colour',
+  getTabColor('nope', tabs) === 'red');
+
+console.log('\n' + (failed === 0 ? 'ALL PASS' : failed + ' FAILED') + ' (' + passed + ' passed)');
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
### What
This PR overhauls how session instances are displayed in the sidebar, replacing single-pane indicators with a full cross-tab view, and adds click-to-navigate functionality. It also introduces positional UI colors to the tabs in the top strip to make finding active sessions intuitive.

### Why
Previously, the sidebar only showed an indicator for a session if it was open in the currently active tab. This caused a "blind spot" where users couldn't easily see if a session was open in background tabs. 

### How
**1. Cross-Tab Session Pips:**
- The sidebar now renders one indicator per place a session is open across *all* tabs.
- Each pip is a 10×10 square showing a top colored bar mapping to the Tab's positional color, and a bottom section mapping to the Pane Slot color.
- Added tooltips to pips showing the target location (`<tab name> › slot N`).

**2. Tab Strip Colors:**
- Each tab in the top strip now carries a positional color (using a saturated rainbow palette: red, yellow, green, teal, blue, mauve) that is inferred from the global tab position regardless of tab group. I found this to be less confusing than using the in-group position, as the same tab colors would dominate the pips which might confuse the user and we would have to include the tab-group's color in the pip, further cluttering the visual representation.
- This color is applied to the tab's dot, its name, and a 2px active underline.
- Inactive tabs dim their opacity but preserve their base hue.

**3. Click-to-Navigate & Pulse:**
- Clicking on a sidebar instance indicator pip now instantly navigates the workspace to that specific tab and pane.
- Navigating to a pane triggers a short, layered visual pulse animation over the target pane area (using an `::after` overlay so it isn't completely hidden by the xterm.js instance) to immediately draw the user's eye.

**4. Under the Hood (`instance-colors.js`):**
- Extracted pure data logic into a new UMD module (`src/web/public/instance-colors.js`) to handle color allocation and instance lookups.
- Centralized tab layout/pane mutations inside `saveTerminalLayout()`.
- Added Node-runnable unit tests (`test/instance-colors.test.js`) for the new module.