### PR TITLE
fix(ui): folder right-click "New Session" respects the project provider

### DIFF
--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -1852,7 +1852,10 @@ class CWMApp {
         if (header) {
           e.preventDefault(); e.stopPropagation();
           const accordion = header.closest('.project-accordion');
-          this.showProjectContextMenu(accordion.dataset.encoded, header.querySelector('.project-name').textContent, accordion.dataset.path, e.clientX, e.clientY);
+          // Forward the project's provider so "New Session Here" spawns the
+          // right CLI (was always Claude before — see showProjectContextMenu).
+          const accProvider = (accordion && accordion.dataset.provider) || 'claude'; /* gsd:provider-literal-allowed (back-compat default) */
+          this.showProjectContextMenu(accordion.dataset.encoded, header.querySelector('.project-name').textContent, accordion.dataset.path, e.clientX, e.clientY, accProvider);
         }
       });
 
@@ -1917,7 +1920,8 @@ class CWMApp {
             const touch = e.touches[0];
             if (touch) {
               const accordion = header.closest('.project-accordion');
-              this.showProjectContextMenu(accordion.dataset.encoded, header.querySelector('.project-name').textContent, accordion.dataset.path, touch.clientX, touch.clientY);
+              const accProvider = (accordion && accordion.dataset.provider) || 'claude'; /* gsd:provider-literal-allowed (back-compat default, mirrors mouse contextmenu) */
+              this.showProjectContextMenu(accordion.dataset.encoded, header.querySelector('.project-name').textContent, accordion.dataset.path, touch.clientX, touch.clientY, accProvider);
             }
           }, 500);
         }
@@ -3400,9 +3404,14 @@ class CWMApp {
     this._renderContextItems(projectName, items, x, y);
   }
 
-  showProjectContextMenu(encodedName, displayName, projectPath, x, y) {
+  showProjectContextMenu(encodedName, displayName, projectPath, x, y, projectProvider) {
     const items = [];
     const isHidden = this.state.hiddenProjects.has(encodedName);
+    // The project accordion in the sidebar carries data-provider on the parent
+    // element. The caller passes it through so the "New Session" menu items
+    // below can spawn the right CLI for the folder (was always 'claude' before
+    // this — right-clicking a Codex folder opened a Claude session).
+    const resolvedProjectProvider = projectProvider || 'claude'; /* gsd:provider-literal-allowed (back-compat default for callers that don't pass) */
 
     // Hide/unhide entire project
     if (isHidden) {
@@ -3440,41 +3449,64 @@ class CWMApp {
     if (projectPath) {
       items.push({ type: 'sep' });
 
-      // New Claude session in this project directory
-      items.push({
-        label: 'New Session Here', icon: '&#9654;', action: () => {
-          const emptySlot = this.terminalPanes.findIndex(p => p === null);
-          if (emptySlot === -1) {
-            this.showToast('All terminal panes full. Close one first.', 'warning');
-            return;
-          }
-          const sid = 'proj-' + Date.now().toString(36);
-          this.setViewMode('terminal');
-          this.openTerminalInPane(emptySlot, sid, displayName, {
-            cwd: projectPath,
-            command: 'claude', // gsd:provider-literal-allowed (v1.1 frontend default; refactor deferred to Phase 18)
-          });
-        },
-      });
+      // Build provider-aware "New Session" items. Folder's native provider
+      // appears first; any other enabled provider follows. This replaces the
+      // pre-Phase-18 hard-coded "command: 'claude'" path that always opened a
+      // Claude session regardless of the folder's provider — right-clicking a
+      // Codex folder used to start the wrong CLI.
+      const enabled = (this.state.providers || []).filter(p => p && p.enabled);
+      const ordered = enabled.length
+        ? enabled.slice().sort((a, b) =>
+            a.id === resolvedProjectProvider ? -1
+              : b.id === resolvedProjectProvider ? 1
+              : 0)
+        : [{ id: 'claude', displayName: 'Claude', enabled: true }]; /* gsd:provider-literal-allowed (last-resort default if providers haven't loaded) */
 
-      items.push({
-        label: 'New Session (Bypass)', icon: '&#9888;', action: () => {
-          const emptySlot = this.terminalPanes.findIndex(p => p === null);
-          if (emptySlot === -1) {
-            this.showToast('All terminal panes full. Close one first.', 'warning');
-            return;
-          }
-          const sid = 'proj-' + Date.now().toString(36);
-          this.setViewMode('terminal');
-          this.openTerminalInPane(emptySlot, sid, displayName, {
-            cwd: projectPath,
-            command: 'claude', // gsd:provider-literal-allowed (v1.1 frontend default; refactor deferred to Phase 18)
-            bypassPermissions: true,
-          });
-        },
-      });
+      for (const prov of ordered) {
+        const providerId = prov.id;
+        const providerLabel = prov.displayName
+          || (providerId.charAt(0).toUpperCase() + providerId.slice(1));
+        const cliBinary = this.getProviderCliBinary(providerId);
 
-      // Start a new session with project context pre-injected
+        items.push({
+          label: 'New ' + providerLabel + ' Session Here', icon: '&#9654;', action: () => {
+            const emptySlot = this.terminalPanes.findIndex(p => p === null);
+            if (emptySlot === -1) {
+              this.showToast('All terminal panes full. Close one first.', 'warning');
+              return;
+            }
+            const sid = 'proj-' + Date.now().toString(36);
+            this.setViewMode('terminal');
+            this.openTerminalInPane(emptySlot, sid, displayName, {
+              cwd: projectPath,
+              command: cliBinary,
+              provider: providerId,
+            });
+          },
+        });
+
+        items.push({
+          label: 'New ' + providerLabel + ' Session (Bypass)', icon: '&#9888;', action: () => {
+            const emptySlot = this.terminalPanes.findIndex(p => p === null);
+            if (emptySlot === -1) {
+              this.showToast('All terminal panes full. Close one first.', 'warning');
+              return;
+            }
+            const sid = 'proj-' + Date.now().toString(36);
+            this.setViewMode('terminal');
+            this.openTerminalInPane(emptySlot, sid, displayName, {
+              cwd: projectPath,
+              command: cliBinary,
+              provider: providerId,
+              bypassPermissions: true,
+            });
+          },
+        });
+      }
+
+      // Start a new session with project context pre-injected.
+      // Currently Claude-only (relies on Claude's --append-system-prompt flag).
+      // Surfaced regardless of project provider since the action is opt-in.
       items.push({
         label: 'Start with Context', icon: '&#128218;', action: () => this.startProjectWithContext(projectPath),
       });

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -3409,8 +3409,10 @@ class CWMApp {
     const isHidden = this.state.hiddenProjects.has(encodedName);
     // The project accordion in the sidebar carries data-provider on the parent
     // element. The caller passes it through so the "New Session" menu items
-    // below can spawn the right CLI for the folder (was always 'claude' before
-    // this — right-clicking a Codex folder opened a Claude session).
+    // below can spawn the right CLI for the folder (was previously hard-coded
+    // to the Claude CLI, so right-clicking a Codex folder opened a Claude
+    // session). Default falls back to the bootstrap provider when callers
+    // pre-date this parameter or state.providers has not loaded yet.
     const resolvedProjectProvider = projectProvider || 'claude'; /* gsd:provider-literal-allowed (back-compat default for callers that don't pass) */
 
     // Hide/unhide entire project
@@ -3451,8 +3453,8 @@ class CWMApp {
 
       // Build provider-aware "New Session" items. Folder's native provider
       // appears first; any other enabled provider follows. This replaces the
-      // pre-Phase-18 hard-coded "command: 'claude'" path that always opened a
-      // Claude session regardless of the folder's provider — right-clicking a
+      // pre-Phase-18 hard-coded command path that always opened a Claude
+      // session regardless of the folder's provider, so right-clicking a
       // Codex folder used to start the wrong CLI.
       const enabled = (this.state.providers || []).filter(p => p && p.enabled);
       const ordered = enabled.length


### PR DESCRIPTION
## Summary
Right-clicking a Codex folder in the discovered-projects sidebar always opened a Claude session, because `showProjectContextMenu` hard-coded `command: 'claude'` and didn't receive the folder's provider. Companion session-level menu was fixed in alpha.5 (Plan 22-04); the folder-level menu was missed.

## Changes
- `showProjectContextMenu(encodedName, displayName, projectPath, x, y, projectProvider)` — new param.
- Both callers (mouse contextmenu, long-press touch) now forward `accordion.dataset.provider`.
- The two hard-coded items become one pair per enabled provider, with the folder's native provider listed first. Labels: "New Claude Session Here", "New Codex Session Here", etc.
- Each spawn carries `{ command: cliBinary, provider: providerId }` so PTY dispatch + pane tagging stay deterministic (Plan 19-01 PTY-02 / PTY-07).

## Test plan
- [x] `test/pane-context-menu.test.js` 9/9
- [x] `test/data-provider-attr.test.js` 11/11
- [x] `test/layout-provider-persist.test.js` 7/7
- [ ] CI green on this PR
- [ ] Manual: right-click a Codex folder → "New Codex Session Here" appears first

JS asset is statically served, so a browser refresh picks up the new menu without restarting the workbook process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)