### PR TITLE
fix: reliable terminal copy and focused pane lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0-alpha.4] - 2026-07-25
+
+This corrective prerelease closes the live terminal copy regression that remained after alpha.3.
+
+### Changed
+
+- **Workbook pane actions are focused on finished workflows.** The incomplete terminal-backed “Switch to view” menu and empty-pane structured views were removed: they duplicated the full Tasks workspace, produced ephemeral blank panes, and introduced hidden-terminal focus and geometry races. Agent work stays in the canonical Tasks experience, while terminal panes retain the dependable session, copy, mirror, move, and lifecycle actions.
+- **The alpha.3 visual hierarchy is now the default path throughout the shell.** Workbench, Sessions, Tasks, and the centralized System/Myrlin Dark/Myrlin Light theme registry remain primary; secondary utilities stay behind More and pane-specific menus no longer compete with unfinished embedded views.
+
+### Fixed
+
+- **Ctrl+C now uses Chromium/xterm's trusted native copy event.** A selected shortcut is withheld from the PTY so it cannot become ETX/SIGINT, but Workbook no longer cancels the browser default or depends on permission-gated `navigator.clipboard.writeText`. The exact selection copies on localhost, insecure HTTP origins, and embedded browsers that deny the programmatic Clipboard API; the highlight remains available after copying. Explicit menu and button copies keep the universal Clipboard API plus `execCommand` fallback.
+- **Right-click preserves highlighted text through any-motion TUIs.** Workbook blocks the zero-button hover and both right-button edges that Claude Code's `DECSET 1003` mouse mode could consume before `contextmenu`, captures the selection before xterm target handlers run, and binds Copy and Save to Notes to that exact snapshot.
+- **Select-mode drag no longer double-focuses or resizes the pane.** The synthetic Shift-mousedown restarts ancestor capture; the app now recognizes an already-active terminal surface and avoids a second focus/activate cycle that could trigger a TUI redraw and erase the selection. Clicking active pane chrome still retains the existing click-anywhere-to-focus behavior.
+- **Moved and cached terminals keep the correct host.** Pane swaps and tab-group cache restores now detach and rebind Select controls, capture listeners, touch handlers, resize observation, focus ownership, provider chrome, and xterm owner identity to the destination slot instead of leaving stale controls and cross-pane routing behind.
+- **Shared pane slots reject stale asynchronous work.** Deferred mounts, voice punctuation/restarts, image uploads, context-menu actions, fatal errors, provider state, attention/activity markers, and auto-trust updates are fenced to the pane and tab group that initiated them. Closing, moving, caching, or reusing a slot cannot write into or activate its new owner.
+- **Mobile terminal and mirror state survives tab-group changes.** The mobile selector is rebuilt from the active group, clears stale active classes, remembers a selected mirror, hides terminal-only controls for mirrors, and restores each mirror’s pinned-to-bottom or manual scroll position after switching away and back.
+- **Fresh builds cannot reuse stale copy assets.** Terminal, shell, and mirror scripts carry a new cache token so a browser that previously loaded the broken event path receives this release’s copy and host-ownership code.
+
+### Testing
+
+- The Windows Chromium/xterm acceptance fixture now enables true any-motion mouse reporting (`DECSET 1003`), proves unselected hover reaches the PTY, and proves selected hover plus right-click do not. It verifies trusted native Ctrl+C, exact OS clipboard text, retained selection, zero SIGINT, denied programmatic Clipboard API behavior, explicit menu-copy failure truthfulness, and both secure and genuinely insecure origins.
+- Added executable event-order and host-ownership regressions for active versus inactive Select-mode drag, pane swaps, group-cache restoration, and stale-slot event routing, plus mobile mirror-selection and scroll-state coverage.
+
 ## [1.3.0-alpha.3] - 2026-07-25
 
 This prerelease consolidates the 1.3 alpha work into a calmer, more dependable Workbook:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myrlin-workbook",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myrlin-workbook",
-      "version": "1.3.0-alpha.3",
+      "version": "1.3.0-alpha.4",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myrlin-workbook",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "description": "Browser-based project manager for AI coding assistants (Claude Code, ChatGPT Codex). Multi-provider session discovery, search, live terminals, docs, kanban, themes.",
   "main": "src/index.js",
   "bin": {

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -16883,8 +16883,7 @@ class CWMApp {
       'terminal-pane-done',
       'mobile-active'
     );
-      paneEl.classList.add('terminal-pane-empty');
-      paneEl.classList.remove('mobile-active');
+    paneEl.classList.add('terminal-pane-empty');
     paneEl.removeAttribute('data-provider');
     delete paneEl.dataset.attentionState;
     delete paneEl.dataset.needsInput;

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -233,6 +233,9 @@ class CWMApp {
     this.terminalPanes = new Array(CWMApp.MAX_PANES).fill(null);
     this._activeTerminalSlot = null;
     this._paneRefreshTimers = {};
+    // Generation counters fence asynchronous structured-view renders from
+    // fixed slots that have since been reused by a swap or tab-group switch.
+    this._paneViewGenerations = new Array(CWMApp.MAX_PANES).fill(0);
     // Issue #10 Phase 4: MirrorPaneView instances by slot index. Mirror
     // panes are standalone (no TerminalPane in the slot), so occupancy
     // checks route through _isSlotOccupied / _findEmptyPaneSlot instead of
@@ -969,7 +972,9 @@ class CWMApp {
       this.els.imageUploadInput.addEventListener('change', (e) => {
         const file = e.target.files[0];
         if (!file) return;
-        this.handleImageUpload(file, this._uploadTargetSlot);
+        const target = this._uploadTarget;
+        this._uploadTarget = null;
+        this.handleImageUpload(file, target);
         e.target.value = ''; // Reset so same file can be re-selected
       });
     }
@@ -1420,15 +1425,6 @@ class CWMApp {
       this.showToast(msg, 'warning');
     });
 
-    // ─── Clipboard Copy Unavailable ──────────────────────────
-    // Selected Ctrl+C is always consumed so it cannot become SIGINT. When
-    // both Clipboard API and execCommand paths fail, TerminalPane keeps the
-    // selection and dispatches this event instead of silently claiming
-    // success or discarding the user's only recoverable copy.
-    document.addEventListener('cwm:copy-unavailable', () => {
-      this.showToast('Copy was blocked by the browser. Selection kept.', 'error');
-    });
-
     // ─── Terminal Needs-Input Badge ─────────────────────────
     // When auto-trust detects a question it won't auto-answer, show/hide
     // an amber "Needs input" badge on the terminal pane header.
@@ -1626,7 +1622,10 @@ class CWMApp {
 
         // Image upload trigger
         if (key === 'upload') {
-          this._uploadTargetSlot = this._activeTerminalSlot;
+          this._uploadTarget = {
+            terminalPane: activePane,
+            groupId: this._activeGroupId,
+          };
           if (this.els.imageUploadInput) this.els.imageUploadInput.click();
           return;
         }
@@ -1643,10 +1642,8 @@ class CWMApp {
             // Closing: hide input row
             if (inputRow) inputRow.classList.remove('active');
             if (inputField) inputField.blur();
-            document.querySelectorAll('.toolbar-keyboard').forEach(kb => {
-              kb.classList.remove('toolbar-active');
-              kb.textContent = '\u2328 Type';
-            });
+            btn.classList.remove('toolbar-active');
+            btn.textContent = '\u2328 Type';
           } else {
             // Opening: show input row and focus
             if (inputRow) inputRow.classList.add('active');
@@ -1654,10 +1651,8 @@ class CWMApp {
               inputField.value = '';
               inputField.focus();
             }
-            document.querySelectorAll('.toolbar-keyboard').forEach(kb => {
-              kb.classList.add('toolbar-active');
-              kb.textContent = '\u2328 Typing';
-            });
+            btn.classList.add('toolbar-active');
+            btn.textContent = '\u2328 Typing';
           }
           return;
         }
@@ -1665,9 +1660,21 @@ class CWMApp {
         // Copy terminal content to clipboard (mobile copy button)
         if (key === 'copy') {
           let textToCopy = '';
-          // If there's an active selection in the terminal, copy that
-          if (activePane.term && activePane.term.hasSelection()) {
-            textToCopy = activePane.term.getSelection();
+          // Prefer the same pane-scoped selection truth used by Ctrl+C and
+          // right-click. On coarse-pointer/rendering fallbacks the browser can
+          // visibly highlight DOM text while xterm reports no model selection;
+          // the mobile toolbar is the reachable copy action in that state.
+          const copySelection = typeof activePane.getCopySelection === 'function'
+            ? activePane.getCopySelection()
+            : {
+                hasSelection: !!(activePane.term &&
+                  activePane.term.hasSelection()),
+                text: activePane.term && activePane.term.hasSelection()
+                  ? activePane.term.getSelection()
+                  : '',
+              };
+          if (copySelection.hasSelection) {
+            textToCopy = String(copySelection.text);
           } else if (activePane.term) {
             // No selection - copy all visible terminal content
             const buffer = activePane.term.buffer.active;
@@ -6003,10 +6010,18 @@ class CWMApp {
       headerStats.style.display = this.state.settings.sessionCountInHeader ? '' : 'none';
     }
 
-    // Sync auto-trust setting to all open terminals
+    // Sync auto-trust setting to every live terminal, including panes cached
+    // in inactive groups. This is a safety policy: disabling it must take
+    // effect immediately even while a pane's DOM is detached.
     const autoTrust = !!this.state.settings.autoTrustDialogs;
-    this.terminalPanes.forEach(tp => {
+    const syncAutoTrust = (tp) => {
       if (tp) tp._autoTrustEnabled = autoTrust;
+    };
+    this.terminalPanes.forEach(syncAutoTrust);
+    Object.values(this._groupPaneCache || {}).forEach(cached => {
+      if (cached && Array.isArray(cached.panes)) {
+        cached.panes.forEach(syncAutoTrust);
+      }
     });
 
     // Sync smooth-scroll setting to every live pane, including panes cached
@@ -6327,7 +6342,7 @@ class CWMApp {
    * @param {HTMLElement} toolbar
    * @param {string} currentDir - the currently shown repo dir
    */
-  _renderTdToolbar(toolbar, currentDir) {
+  _renderTdToolbar(toolbar, currentDir, panel = null) {
     toolbar.textContent = '';
     const label = document.createElement('span');
     label.className = 'tasks-td-toolbar-label';
@@ -6356,7 +6371,7 @@ class CWMApp {
       this._tdPanelDir = sel.value;
       // Mark as manually pinned so pane focus changes don't override the selection
       this._tdPanelDirPinned = (sel.value !== this._getTdPanelDir());
-      this.renderTasksTdPanel();
+      this.renderTasksTdPanel(panel);
     });
 
     toolbar.appendChild(sel);
@@ -6366,7 +6381,7 @@ class CWMApp {
     refreshBtn.className = 'btn btn-ghost btn-icon btn-sm tasks-td-refresh';
     refreshBtn.title = 'Refresh';
     refreshBtn.innerHTML = '&#8635;';
-    refreshBtn.addEventListener('click', () => this.renderTasksTdPanel());
+    refreshBtn.addEventListener('click', () => this.renderTasksTdPanel(panel));
     toolbar.appendChild(refreshBtn);
   }
 
@@ -6423,7 +6438,7 @@ class CWMApp {
       this._tdProjects = projectsData.projects || [];
       // Re-render toolbar if panel is still showing the td view
       const toolbar = panel.querySelector('.tasks-td-toolbar');
-      if (toolbar) this._renderTdToolbar(toolbar, dir);
+      if (toolbar) this._renderTdToolbar(toolbar, dir, panel);
     }).catch(() => {});
 
     try {
@@ -6433,7 +6448,7 @@ class CWMApp {
       panel.textContent = '';
       const toolbar = document.createElement('div');
       toolbar.className = 'tasks-td-toolbar';
-      this._renderTdToolbar(toolbar, dir);
+      this._renderTdToolbar(toolbar, dir, panel);
       panel.appendChild(toolbar);
 
       if (issues.length === 0) {
@@ -6519,7 +6534,7 @@ class CWMApp {
         panel.textContent = '';
         const toolbar = document.createElement('div');
         toolbar.className = 'tasks-td-toolbar';
-        this._renderTdToolbar(toolbar, dir);
+        this._renderTdToolbar(toolbar, dir, panel);
         panel.appendChild(toolbar);
         const wrap = document.createElement('div');
         wrap.style.cssText = 'display:flex;flex-direction:column;align-items:center;gap:12px;padding:32px 24px;';
@@ -6545,7 +6560,7 @@ class CWMApp {
               // Fallback: run td init via a generic endpoint if workspace isn't known
               throw new Error('No active workspace to run td init against. Run `td init` manually in ' + dir);
             }
-            this.renderTasksTdPanel();
+            this.renderTasksTdPanel(panel);
           } catch (e) {
             initBtn.disabled = false;
             initBtn.textContent = 'Run td init';
@@ -14862,7 +14877,10 @@ class CWMApp {
             e.stopPropagation();
             const tp = this.terminalPanes[slotIdx];
             if (!tp) return;
-            this._uploadTargetSlot = slotIdx;
+            this._uploadTarget = {
+              terminalPane: tp,
+              groupId: this._activeGroupId,
+            };
             if (this.els.imageUploadInput) this.els.imageUploadInput.click();
           });
         }
@@ -14943,10 +14961,8 @@ class CWMApp {
         }
 
         // Click-to-focus: clicking/tapping anywhere in a pane focuses its terminal
-        const focusPane = () => {
-          if (this.terminalPanes[slotIdx]) {
-            this.setActiveTerminalPane(slotIdx);
-          }
+        const focusPane = (event) => {
+          this._focusTerminalPaneFromPointer(slotIdx, event);
         };
         pane.addEventListener('mousedown', focusPane, true); // capture phase
         pane.addEventListener('touchstart', focusPane, { passive: true, capture: true });
@@ -14961,12 +14977,26 @@ class CWMApp {
 
         // Right-click context menu on terminal pane
         pane.addEventListener('contextmenu', (e) => {
-          const tp = this.terminalPanes[slotIdx];
-          if (!tp) { e.preventDefault(); e.stopPropagation(); this._showEmptyPaneContextMenu(slotIdx, e.clientX, e.clientY); return; }
+          const tp = this._terminalPaneFromPointerEvent(slotIdx, e);
+          // Structured views are terminal-backed. An empty slot has no
+          // persistent owner, so leave its native context menu alone instead
+          // of exposing ephemeral views that disappear on the next layout.
+          if (!tp) return;
+          const copySelection = typeof tp.getCopySelection === 'function'
+            ? tp.getCopySelection()
+            : {
+                hasSelection: !!(tp.term && tp.term.hasSelection()),
+                text: tp.term && tp.term.hasSelection() ? tp.term.getSelection() : '',
+                source: 'xterm',
+              };
           e.preventDefault();
           e.stopPropagation();
-          this.showTerminalContextMenu(slotIdx, e.clientX, e.clientY);
-        });
+          // Capture before xterm's target-level contextmenu handler moves and
+          // selects its hidden textarea. The menu is Workbook-owned, so xterm
+          // has no useful native context-menu work to do here; preserving this
+          // snapshot keeps both xterm and visible DOM selections truthful.
+          this.showTerminalContextMenu(slotIdx, e.clientX, e.clientY, copySelection, tp);
+        }, true);
 
         // Long-press for mobile terminal context menu
         let termLongPress = null;
@@ -15026,7 +15056,86 @@ class CWMApp {
   // (wrong pane on reconnect, unclosable panes, broken layout). Panes now connect
   // directly on restore and close cleanly on fatal error.
 
+  _mountTerminalPaneOnNextFrame(tp, ownerGroupId, activate = true) {
+    const activationGeneration = tp._mountActivationGeneration || 0;
+    return requestAnimationFrame(() => {
+      if (this._activeGroupId !== ownerGroupId) return;
+      const liveSlot = this.terminalPanes.indexOf(tp);
+      if (liveSlot < 0) return;
+      this._syncTerminalPaneHost(liveSlot, tp);
+      // A rapid away/back group cycle can queue a second restore callback for
+      // the same not-yet-mounted pane. The first callback owns construction;
+      // later callbacks may rebind/activate but must not create another xterm
+      // or WebSocket.
+      if (!tp.term) tp.mount();
+      const shouldActivate = activate === true ||
+        (activate === 'if-active' && this._activeTerminalSlot === liveSlot);
+      if (shouldActivate &&
+          (tp._mountActivationGeneration || 0) === activationGeneration &&
+          this._activeGroupId === ownerGroupId &&
+          this.terminalPanes[liveSlot] === tp) {
+        this.setActiveTerminalPane(liveSlot);
+      }
+    });
+  }
+
+  /**
+   * Tear down a TerminalPane that exhausted its connection retries.
+   * The pane may be visible or cached in an inactive terminal group.
+   */
+  _handleTerminalPaneFatal(tp) {
+    if (!tp) return false;
+
+    const liveSlot = this.terminalPanes.indexOf(tp);
+    if (liveSlot >= 0) {
+      tp.dispose();
+      this.terminalPanes[liveSlot] = null;
+      this._resetTerminalPaneHost(liveSlot);
+      if (this._activeTerminalSlot === liveSlot) {
+        const nextSlot = this.terminalPanes.findIndex(candidate => candidate);
+        this._activeTerminalSlot = nextSlot >= 0 ? nextSlot : null;
+        if (nextSlot >= 0) this.setActiveTerminalPane(nextSlot);
+      }
+      this.updateTerminalGridLayout();
+      this.saveTerminalLayout();
+      return true;
+    }
+
+    for (const [groupId, cached] of Object.entries(this._groupPaneCache || {})) {
+      if (!cached || !Array.isArray(cached.panes)) continue;
+      const cachedSlot = cached.panes.indexOf(tp);
+      if (cachedSlot < 0) continue;
+
+      tp.dispose();
+      cached.panes[cachedSlot] = null;
+      if (Array.isArray(cached.domFragments)) {
+        cached.domFragments[cachedSlot] = null;
+      }
+      if (cached.activePane === tp) cached.activePane = null;
+      if (cached.activeSlot === cachedSlot) {
+        const nextSlot = cached.panes.findIndex(candidate => candidate);
+        cached.activeSlot = nextSlot >= 0 ? nextSlot : null;
+        cached.activePane = nextSlot >= 0 ? cached.panes[nextSlot] : null;
+      }
+
+      const group = (this._tabGroups || []).find(candidate => candidate.id === groupId);
+      if (group && Array.isArray(group.panes)) {
+        group.panes = group.panes.filter(record =>
+          !(record && record.slot === cachedSlot &&
+            record.sessionId === tp.sessionId)
+        );
+      }
+      this.saveTerminalLayout();
+      return true;
+    }
+    return false;
+  }
+
   openTerminalInPane(slotIdx, sessionId, sessionName, spawnOpts) {
+    // A terminal belongs to the tab group that initiated the open. The actual
+    // xterm mount is deferred one frame so the grid has dimensions; keep that
+    // deferred work from crossing a group switch into a reused fixed slot.
+    const ownerGroupId = this._activeGroupId;
     // Check localStorage for a previously saved name for this session
     const savedTitle = this.getProjectSessionTitle(sessionId);
     if (savedTitle && (!sessionName || sessionName === sessionId)) {
@@ -15040,6 +15149,7 @@ class CWMApp {
         slotIdx = emptySlot;
       } else {
         // All slots full, replace the target slot
+        this._discardVoiceRecognition(slotIdx, this.terminalPanes[slotIdx]);
         this.terminalPanes[slotIdx].dispose();
         this.terminalPanes[slotIdx] = null;
       }
@@ -15063,6 +15173,10 @@ class CWMApp {
         delete mirrorPaneEl.dataset.viewData;
       }
     }
+    // A normal tasks/doc view is fixed-host state too. Opening a different
+    // terminal into this slot invalidates any in-flight render/timer and
+    // restores the terminal surface before new ownership is attached.
+    this._resetTerminalPaneHost(slotIdx);
 
     const containerId = `term-container-${slotIdx}`;
     const paneEl = document.getElementById(`term-pane-${slotIdx}`);
@@ -15084,9 +15198,14 @@ class CWMApp {
       .concat(Object.values(this.state.sessions || {}))
       .find(_s => _s && _s.id === sessionId);
     const _explicitProvider = spawnOpts && spawnOpts.provider;
-    paneEl.dataset.provider = _explicitProvider
+    const _resolvedProvider = _explicitProvider
       || (_sessForProvider && _sessForProvider.provider)
       || 'claude'; /* gsd:provider-literal-allowed (Phase 18 default) */
+    paneEl.dataset.provider = _resolvedProvider;
+    // Keep the resolved provider on the TerminalPane itself. Deferred host
+    // sync runs before mount, so relying on the constructor's temporary
+    // _providerId default would overwrite a correct Codex pane as Claude.
+    spawnOpts = { ...(spawnOpts || {}), provider: _resolvedProvider };
 
     // Update pane state
     paneEl.classList.remove('terminal-pane-empty');
@@ -15144,40 +15263,8 @@ class CWMApp {
       this._attentionStateForSession(sessionId, rosterSession && rosterSession.status)
     );
 
-    // Wire up mobile mode change callback to sync keyboard toggle button
-    tp.onMobileModeChange = (mode) => {
-      document.querySelectorAll('.toolbar-keyboard').forEach(kb => {
-        kb.classList.toggle('toolbar-active', mode === 'type');
-        kb.textContent = mode === 'type' ? '\u2328 Typing' : '\u2328 Type';
-      });
-    };
-
     // On fatal connection error, close the pane cleanly.
-    tp.onFatalError = (failedSessionId) => {
-      const idx = this.terminalPanes.indexOf(tp);
-      if (idx === -1) return;
-      tp.dispose();
-      this.terminalPanes[idx] = null;
-      const deadPane = document.getElementById(`term-pane-${idx}`);
-      if (deadPane) {
-        // Close the schedule popover if it was anchored to this pane.
-        if (window.SchedulePopover && window.SchedulePopover.anchor && deadPane.contains(window.SchedulePopover.anchor)) {
-          window.SchedulePopover.close();
-        }
-        deadPane.classList.add('terminal-pane-empty');
-        deadPane.removeAttribute('data-provider');
-        const header = deadPane.querySelector('.terminal-pane-title');
-        if (header) header.textContent = 'Drop a session here';
-        const closeBtn2 = deadPane.querySelector('.terminal-pane-close');
-        if (closeBtn2) closeBtn2.hidden = true;
-        const scheduleBtn3 = deadPane.querySelector('.terminal-pane-schedule');
-        if (scheduleBtn3) scheduleBtn3.hidden = true;
-        // Plan 22-02: hide the provider pill when the pane goes empty.
-        const pillElDead = deadPane.querySelector('.pane-provider-pill');
-        if (pillElDead) { pillElDead.hidden = true; pillElDead.textContent = ''; pillElDead.removeAttribute('data-provider'); }
-      }
-      this.updateTerminalGridLayout();
-    };
+    tp.onFatalError = () => this._handleTerminalPaneFatal(tp);
 
     // Enable auto-trust if the setting is on
     tp._autoTrustEnabled = !!this.state.settings.autoTrustDialogs;
@@ -15186,11 +15273,11 @@ class CWMApp {
     // then mount the terminal so fitAddon.fit() gets real dimensions.
     this.updateTerminalGridLayout();
 
-    // Use rAF to let the browser paint the grid before mounting terminal
-    requestAnimationFrame(() => {
-      tp.mount();
-      this.setActiveTerminalPane(slotIdx);
-    });
+    // Use rAF to let the browser paint the grid before mounting terminal.
+    // Resolve the pane by identity at execution time: a same-group drag may
+    // legitimately move it before this frame, while close/group-switch must
+    // cancel the stale mount instead of resurrecting it in a reused host.
+    this._mountTerminalPaneOnNextFrame(tp, ownerGroupId, true);
 
     // Clear activity indicator for the new pane
     const activityEl = document.getElementById(`term-activity-${slotIdx}`);
@@ -15211,10 +15298,66 @@ class CWMApp {
   }
 
   /**
+   * Invalidate asynchronous work owned by a pane view.
+   * @returns {number} the new generation for this fixed slot.
+   */
+  _invalidatePaneView(slotIdx) {
+    if (!this._paneViewGenerations) {
+      this._paneViewGenerations = new Array(CWMApp.MAX_PANES).fill(0);
+    }
+    this._paneViewGenerations[slotIdx] =
+      (this._paneViewGenerations[slotIdx] || 0) + 1;
+    if (this._paneRefreshTimers && this._paneRefreshTimers[slotIdx]) {
+      clearInterval(this._paneRefreshTimers[slotIdx]);
+      delete this._paneRefreshTimers[slotIdx];
+    }
+    return this._paneViewGenerations[slotIdx];
+  }
+
+  _isPaneViewTokenCurrent(slotIdx, token) {
+    if (!token || !this._paneViewGenerations) return false;
+    const paneEl = document.getElementById(`term-pane-${slotIdx}`);
+    return this._activeGroupId === token.groupId &&
+      this._paneViewGenerations[slotIdx] === token.generation &&
+      this.terminalPanes[slotIdx] === token.terminalPane &&
+      !!paneEl &&
+      paneEl.dataset.viewType === token.viewType;
+  }
+
+  /**
+   * Clear all structured-view state owned by a reusable fixed host.
+   * TerminalPane/xterm ownership is handled separately.
+   */
+  _clearPaneViewHost(slotIdx, options = {}) {
+    const disposeMirror = options.disposeMirror !== false;
+    this._invalidatePaneView(slotIdx);
+    if (disposeMirror && this._mirrorPanes && this._mirrorPanes[slotIdx]) {
+      try { this._mirrorPanes[slotIdx].dispose(); } catch (_) { /* already gone */ }
+      delete this._mirrorPanes[slotIdx];
+    }
+    const paneEl = document.getElementById(`term-pane-${slotIdx}`);
+    const termContainer = document.getElementById(`term-container-${slotIdx}`);
+    const viewContainer = document.getElementById(`pane-view-${slotIdx}`);
+    if (viewContainer) {
+      viewContainer.hidden = true;
+      viewContainer.replaceChildren();
+    }
+    if (termContainer) termContainer.hidden = false;
+    if (paneEl) {
+      const badge = paneEl.querySelector('.pane-view-badge');
+      const backBtn = paneEl.querySelector('.pane-view-back');
+      if (badge) { badge.hidden = true; badge.textContent = ''; }
+      if (backBtn) backBtn.hidden = true;
+      delete paneEl.dataset.viewType;
+      delete paneEl.dataset.viewData;
+    }
+  }
+
+  /**
    * Replace the terminal in a pane with a structured view (tasks, doc, etc.).
    * The terminal is hidden but not disposed; restoreTerminalInPane() brings it back.
    * @param {number} slotIdx - The pane slot index
-   * @param {string} viewType - One of: 'tasks-git', 'tasks-td', 'tasks-worktree', 'tasks-files', 'doc'
+   * @param {string} viewType - One of: 'tasks-git', 'tasks-td', 'tasks-files', 'doc'
    * @param {Object} [viewData={}] - Optional view-specific data (e.g. { docId } for doc views)
    */
   async openViewInPane(slotIdx, viewType, viewData = {}) {
@@ -15224,14 +15367,19 @@ class CWMApp {
     const viewContainer = document.getElementById(`pane-view-${slotIdx}`);
     if (!termContainer || !viewContainer) return;
 
+    this._clearPaneViewHost(slotIdx);
+    const token = {
+      generation: this._paneViewGenerations[slotIdx],
+      groupId: this._activeGroupId,
+      terminalPane: this.terminalPanes[slotIdx],
+      viewType,
+    };
     termContainer.hidden = true;
     viewContainer.hidden = false;
-    viewContainer.replaceChildren();
 
     const labels = {
       'tasks-git': 'Git',
       'tasks-td': 'Issues',
-      'tasks-worktree': 'Agent Tasks',
       'tasks-files': 'Files',
       'doc': 'Markdown',
       'mirror': 'Mirror'
@@ -15244,7 +15392,14 @@ class CWMApp {
     paneEl.dataset.viewType = viewType;
     paneEl.dataset.viewData = JSON.stringify(viewData);
 
-    await this._renderPaneView(slotIdx, viewType, viewData, viewContainer);
+    const rendered = await this._renderPaneView(
+      slotIdx,
+      viewType,
+      viewData,
+      viewContainer,
+      token
+    );
+    if (!rendered || !this._isPaneViewTokenCurrent(slotIdx, token)) return;
     this.saveTerminalLayout();
   }
 
@@ -15256,31 +15411,7 @@ class CWMApp {
   restoreTerminalInPane(slotIdx) {
     const paneEl = document.getElementById(`term-pane-${slotIdx}`);
     if (!paneEl) return;
-    const termContainer = document.getElementById(`term-container-${slotIdx}`);
-    const viewContainer = document.getElementById(`pane-view-${slotIdx}`);
-
-    // Issue #10 Phase 4: a mirror view holds a server-side subscription;
-    // release it (POSTs /api/mirror/close) before the container is cleared.
-    if (this._mirrorPanes[slotIdx]) {
-      try { this._mirrorPanes[slotIdx].dispose(); } catch (_) { /* already gone */ }
-      delete this._mirrorPanes[slotIdx];
-    }
-
-    if (viewContainer) { viewContainer.hidden = true; viewContainer.replaceChildren(); }
-    if (termContainer) termContainer.hidden = false;
-
-    const badge = paneEl.querySelector('.pane-view-badge');
-    const backBtn = paneEl.querySelector('.pane-view-back');
-    if (badge) badge.hidden = true;
-    if (backBtn) backBtn.hidden = true;
-
-    delete paneEl.dataset.viewType;
-    delete paneEl.dataset.viewData;
-
-    if (this._paneRefreshTimers[slotIdx]) {
-      clearInterval(this._paneRefreshTimers[slotIdx]);
-      delete this._paneRefreshTimers[slotIdx];
-    }
+    this._clearPaneViewHost(slotIdx);
 
     const tp = this.terminalPanes[slotIdx];
     if (tp && tp.safeFit) tp.safeFit();
@@ -15305,40 +15436,61 @@ class CWMApp {
    * @param {Object} viewData - View-specific data
    * @param {HTMLElement} container - The container element to render into
    */
-  async _renderPaneView(slotIdx, viewType, viewData, container) {
-    if (this._paneRefreshTimers[slotIdx]) {
-      clearInterval(this._paneRefreshTimers[slotIdx]);
-      delete this._paneRefreshTimers[slotIdx];
+  async _renderPaneView(slotIdx, viewType, viewData, container, token) {
+    if (!this._isPaneViewTokenCurrent(slotIdx, token)) return false;
+    if (viewType === 'mirror') {
+      const view = await this._renderMirrorInPane(slotIdx, container, viewData);
+      if (!this._isPaneViewTokenCurrent(slotIdx, token)) {
+        if (view && this._mirrorPanes[slotIdx] === view) {
+          try { view.dispose(); } catch (_) { /* already gone */ }
+          delete this._mirrorPanes[slotIdx];
+        }
+        return false;
+      }
+      return true;
     }
+
+    // Render into a detached staging element. Async view renderers may finish
+    // after a group switch; only the current owner generation may commit DOM
+    // into the shared fixed-slot container.
+    const staging = document.createElement('div');
     switch (viewType) {
       case 'tasks-git':
-        await this.renderTasksGitPanel(container);
-        // Same guard as the git tasks tab: never poll while the browser tab is
-        // hidden, and use the shared, less-aggressive cadence, so a parked
-        // git pane stops spawning git.exe + conhost every 10s on Windows.
-        this._paneRefreshTimers[slotIdx] = setInterval(() => {
-          if (document.hidden) return;
-          this.renderTasksGitPanel(container);
-        }, CWMApp.GIT_PANEL_POLL_MS);
+        await this.renderTasksGitPanel(staging);
         break;
       case 'tasks-td':
-        await this.renderTasksTdPanel(container);
-        break;
-      case 'tasks-worktree':
-        await this.renderTasksView(container);
+        // Keep the rendered panel node itself. Toolbar callbacks capture this
+        // owner and continue to update the visible pane after staging commits.
+        const tdPanel = document.createElement('div');
+        staging.appendChild(tdPanel);
+        await this.renderTasksTdPanel(tdPanel);
         break;
       case 'tasks-files':
-        await this.renderTasksFilesPanel(container);
+        await this.renderTasksFilesPanel(staging);
         break;
       case 'doc':
-        await this._renderDocInPane(container, viewData);
-        break;
-      case 'mirror':
-        // Issue #10 Phase 4: read-only live mirror of an externally-started
-        // provider session. No refresh timer: updates arrive over SSE.
-        await this._renderMirrorInPane(slotIdx, container, viewData);
+        await this._renderDocInPane(staging, viewData);
         break;
     }
+    if (!this._isPaneViewTokenCurrent(slotIdx, token)) return false;
+    container.replaceChildren(...Array.from(staging.childNodes));
+
+    if (viewType === 'tasks-git') {
+      // Poll through a staging container too, so an in-flight refresh can
+      // never paint into a slot whose owner changed while the request ran.
+      const refresh = async () => {
+        if (document.hidden || !this._isPaneViewTokenCurrent(slotIdx, token)) return;
+        const refreshStaging = document.createElement('div');
+        await this.renderTasksGitPanel(refreshStaging);
+        if (!this._isPaneViewTokenCurrent(slotIdx, token)) return;
+        container.replaceChildren(...Array.from(refreshStaging.childNodes));
+      };
+      this._paneRefreshTimers[slotIdx] = setInterval(
+        refresh,
+        CWMApp.GIT_PANEL_POLL_MS
+      );
+    }
+    return true;
   }
 
   /**
@@ -15367,6 +15519,7 @@ class CWMApp {
       provider: vd.provider,
       providerSessionId: vd.providerSessionId,
       title: vd.title || vd.providerSessionId,
+      scrollState: vd.scrollState || null,
       api: (method, path, body) => this.api(method, path, body),
       escapeHtml: (s) => this.escapeHtml(s),
       deviceId: this.deviceId,
@@ -15379,6 +15532,7 @@ class CWMApp {
       // the miss is visible even if the pane is small.
       this.showToast((err && err.message) || 'Failed to open mirror', 'error');
     }
+    return view;
   }
 
   /**
@@ -15397,7 +15551,12 @@ class CWMApp {
     paneEl.classList.remove('terminal-pane-empty');
     const titleEl = paneEl.querySelector('.terminal-pane-title');
     if (titleEl) titleEl.textContent = (viewData && viewData.title) || 'Mirror';
-    await this.openViewInPane(slotIdx, 'mirror', viewData || {});
+    const opening = this.openViewInPane(slotIdx, 'mirror', viewData || {});
+    if (this.isMobile) {
+      this._activeTerminalSlot = slotIdx;
+      this.updateTerminalTabs();
+    }
+    await opening;
     this.updateTerminalGridLayout();
   }
 
@@ -15757,20 +15916,6 @@ class CWMApp {
   }
 
   /**
-   * Context menu shown when right-clicking an empty (no terminal) pane slot.
-   * Offers quick access to all pane view types.
-   */
-  _showEmptyPaneContextMenu(slotIdx, x, y) {
-    const items = [
-      { label: 'Agent Tasks', action: () => this.openViewInPane(slotIdx, 'tasks-worktree') },
-      { label: 'Issues', action: () => this.openViewInPane(slotIdx, 'tasks-td') },
-      { type: 'sep' },
-      { label: 'Project Markdown', action: () => this.openViewInPane(slotIdx, 'doc') },
-    ];
-    this._renderContextItems('Open View', items, x, y);
-  }
-
-  /**
    * Build the "Codex settings" submenu (Plan 21-01).
    *
    * Pure factory: returns an array of menu items suitable for the existing
@@ -16083,36 +16228,58 @@ class CWMApp {
     this._renderContextItems(matchLabel, item.submenu, rect.left, rect.bottom);
   }
 
-  showTerminalContextMenu(slotIdx, x, y) {
-    const tp = this.terminalPanes[slotIdx];
+  showTerminalContextMenu(slotIdx, x, y, copySelection, terminalPane) {
+    const tp = terminalPane || this.terminalPanes[slotIdx];
     if (!tp) return;
+    // Every action in this menu must address the same live owner used for the
+    // copy snapshot. During a pane move/cache transition the fixed DOM
+    // listener's slot can briefly disagree with the stamped xterm owner; using
+    // that stale slot for Restart/Close/Move would mutate a neighboring pane.
+    const ownerSlot = this.terminalPanes
+      ? this.terminalPanes.indexOf(tp)
+      : -1;
+    if (ownerSlot >= 0) slotIdx = ownerSlot;
+    const ownerGroupId = this._activeGroupId;
+    const resolveLiveOwnerSlot = () => {
+      if (this._activeGroupId !== ownerGroupId || !this.terminalPanes) return -1;
+      return this.terminalPanes.indexOf(tp);
+    };
+    const warnStaleOwner = () => {
+      this.showToast('Pane changed while the action was running; no other pane was modified', 'warning');
+    };
 
     const items = [];
+    const selection = copySelection && typeof copySelection === 'object'
+      ? copySelection
+      : (typeof tp.getCopySelection === 'function'
+          ? tp.getCopySelection()
+          : {
+              hasSelection: !!(tp.term && tp.term.hasSelection()),
+              text: tp.term && tp.term.hasSelection() ? tp.term.getSelection() : '',
+              source: 'xterm',
+            });
+    const selectedText = selection.hasSelection ? String(selection.text) : '';
 
     // ── Terminal-specific actions ──────────────────────────────
 
     // Copy selected text (only show when there's a selection)
-    if (tp.term && tp.term.hasSelection()) {
+    if (selection.hasSelection) {
       items.push({
         label: 'Copy', icon: '&#128203;', action: () => {
-          const selected = tp.term.getSelection();
-          if (selected) {
-            this._copyWithToast(selected, 'Copied to clipboard');
-          }
+          this._copyWithToast(selectedText, 'Copied to clipboard');
         },
       });
     }
 
     // Save to Notes (only show when there's a selection)
-    if (tp.term && tp.term.hasSelection()) {
+    if (selection.hasSelection) {
       items.push({
         label: 'Save to Notes', icon: '&#128221;', action: async () => {
-          const selected = tp.term.getSelection();
           const ws = this.state.activeWorkspace;
           if (!ws) { this.showToast('No active workspace', 'error'); return; }
           const result = await this.showPromptModal({
             title: 'Save to Notes',
-            fields: [{ key: 'text', type: 'textarea', value: selected }],
+            fields: [{ key: 'text', type: 'textarea', value: selectedText }],
             confirmText: 'Save Note'
           });
           if (!result) return;
@@ -16166,9 +16333,11 @@ class CWMApp {
         } catch (_) {
           // Session may already be dead, continue with relaunch
         }
-        this.closeTerminalPane(slotIdx);
+        const liveSlot = resolveLiveOwnerSlot();
+        if (liveSlot < 0) { warnStaleOwner(); return; }
+        this.closeTerminalPane(liveSlot);
         // Reopen in the same slot with the same options (resumes the session)
-        this.openTerminalInPane(slotIdx, sid, sName, oldOpts);
+        this.openTerminalInPane(liveSlot, sid, sName, oldOpts);
         this.showToast('Session restarted', 'success');
       },
     });
@@ -16180,7 +16349,9 @@ class CWMApp {
           await this.api('POST', `/api/pty/${encodeURIComponent(tp.sessionId)}/kill`);
           this.showToast('Session killed - drop again to restart', 'warning');
           // Close the terminal pane since the process is dead
-          this.closeTerminalPane(slotIdx);
+          const liveSlot = resolveLiveOwnerSlot();
+          if (liveSlot < 0) { warnStaleOwner(); return; }
+          this.closeTerminalPane(liveSlot);
         } catch (err) {
           this.showToast(err.message || 'Failed to kill session', 'error');
         }
@@ -16217,10 +16388,12 @@ class CWMApp {
           } catch (_) {
             // Session may already be dead, continue with relaunch
           }
-          this.closeTerminalPane(slotIdx);
+          const liveSlot = resolveLiveOwnerSlot();
+          if (liveSlot < 0) { warnStaleOwner(); return; }
+          this.closeTerminalPane(liveSlot);
           // Reopen in the same slot with the new shell
           const newOpts = { ...oldOpts, shell: opt.id };
-          this.openTerminalInPane(slotIdx, sid, sName, newOpts);
+          this.openTerminalInPane(liveSlot, sid, sName, newOpts);
           this.showToast(`Switched to ${opt.label}`, 'success');
         },
       });
@@ -16284,26 +16457,34 @@ class CWMApp {
     const otherGroups = (this._tabGroups || []).filter(g => g.id !== this._activeGroupId);
     if (otherGroups.length > 0) {
       items.push({
-        label: 'Move to Tab...',
-        icon: '&#8594;',
-        submenu: otherGroups.map(g => ({
-          label: g.name,
-          action: () => this.moveTerminalToGroup(slotIdx, g.id),
-        })),
-      });
-    }
+          label: 'Move to Tab...',
+          icon: '&#8594;',
+          submenu: otherGroups.map(g => ({
+            label: g.name,
+            action: () => {
+              const liveSlot = resolveLiveOwnerSlot();
+              if (liveSlot < 0) { warnStaleOwner(); return; }
+              this.moveTerminalToGroup(liveSlot, g.id);
+            },
+          })),
+        });
+      }
 
     // Close pane
     items.push({
       label: 'Close Pane', icon: '&#10005;', action: () => {
-        this.closeTerminalPane(slotIdx);
+        const liveSlot = resolveLiveOwnerSlot();
+        if (liveSlot < 0) { warnStaleOwner(); return; }
+        this.closeTerminalPane(liveSlot);
       },
     });
 
     // Inspect Element - select element in DevTools or log to console
     items.push({
       label: 'Inspect Element', icon: '&#128269;', action: () => {
-        const paneEl = document.getElementById(`term-pane-${slotIdx}`);
+        const liveSlot = resolveLiveOwnerSlot();
+        if (liveSlot < 0) { warnStaleOwner(); return; }
+        const paneEl = document.getElementById(`term-pane-${liveSlot}`);
         if (typeof inspect === 'function') {
           inspect(paneEl);
         } else {
@@ -16313,51 +16494,10 @@ class CWMApp {
       },
     });
 
-    // ── Switch to view ────────────────────────────────────────
-    items.push({ type: 'sep' });
-    items.push({
-      label: 'Switch to view',
-      submenu: [
-        { label: 'Agent Tasks', action: () => this.openViewInPane(slotIdx, 'tasks-worktree') },
-        { label: 'Issues', action: () => this.openViewInPane(slotIdx, 'tasks-td') },
-        { label: 'Project Markdown', action: () => this.openViewInPane(slotIdx, 'doc') },
-      ],
-    });
-
     this._renderContextItems(tp.sessionName || 'Terminal', items, x, y);
   }
 
   closeTerminalPane(slotIdx) {
-    // If our schedule popover is anchored on this pane's clock, close it.
-    if (window.SchedulePopover && window.SchedulePopover.anchor) {
-      const paneElForPopover = document.getElementById(`term-pane-${slotIdx}`);
-      if (paneElForPopover && paneElForPopover.contains(window.SchedulePopover.anchor)) {
-        window.SchedulePopover.close();
-      }
-    }
-    if (this._paneRefreshTimers[slotIdx]) {
-      clearInterval(this._paneRefreshTimers[slotIdx]);
-      delete this._paneRefreshTimers[slotIdx];
-    }
-
-    // Issue #10 Phase 4: release any mirror subscription living in this
-    // slot and clear its view chrome (badge, back button, container).
-    if (this._mirrorPanes[slotIdx]) {
-      try { this._mirrorPanes[slotIdx].dispose(); } catch (_) { /* already gone */ }
-      delete this._mirrorPanes[slotIdx];
-      const paneElMirror = document.getElementById(`term-pane-${slotIdx}`);
-      if (paneElMirror) {
-        const viewContainer = document.getElementById(`pane-view-${slotIdx}`);
-        if (viewContainer) { viewContainer.hidden = true; viewContainer.replaceChildren(); }
-        const mBadge = paneElMirror.querySelector('.pane-view-badge');
-        const mBack = paneElMirror.querySelector('.pane-view-back');
-        if (mBadge) mBadge.hidden = true;
-        if (mBack) mBack.hidden = true;
-        delete paneElMirror.dataset.viewType;
-        delete paneElMirror.dataset.viewData;
-      }
-    }
-
     const tp = this.terminalPanes[slotIdx];
     const sessionName = tp ? tp.sessionName : '';
 
@@ -16369,43 +16509,7 @@ class CWMApp {
 
     const paneEl = document.getElementById(`term-pane-${slotIdx}`);
     if (!paneEl) return;
-
-    // Reset to empty state
-    paneEl.classList.remove('terminal-pane-active');
-    paneEl.classList.add('terminal-pane-empty');
-    paneEl.removeAttribute('data-provider');
-    const titleEl = paneEl.querySelector('.terminal-pane-title');
-    if (titleEl) titleEl.textContent = 'Drop a session here';
-    // Plan 22-02: hide and clear the provider pill when the pane empties.
-    const pillElClose = paneEl.querySelector('.pane-provider-pill');
-    if (pillElClose) { pillElClose.hidden = true; pillElClose.textContent = ''; pillElClose.removeAttribute('data-provider'); }
-    const closeBtn = paneEl.querySelector('.terminal-pane-close');
-    if (closeBtn) closeBtn.hidden = true;
-    const uploadBtn3 = paneEl.querySelector('.terminal-pane-upload');
-    if (uploadBtn3) uploadBtn3.hidden = true;
-    const scheduleBtn3 = paneEl.querySelector('.terminal-pane-schedule');
-    if (scheduleBtn3) {
-      scheduleBtn3.hidden = true;
-      const badge = scheduleBtn3.querySelector('.pane-schedule-count');
-      if (badge) { badge.textContent = ''; badge.hidden = true; }
-    }
-    // Collapse any active expansion before closing
-    this._collapseExpandPane(slotIdx);
-    const expandBtn3 = paneEl.querySelector('.terminal-pane-expand');
-    if (expandBtn3) expandBtn3.hidden = true;
-    const collapseBtn3 = paneEl.querySelector('.terminal-pane-collapse');
-    if (collapseBtn3) collapseBtn3.hidden = true;
-    // Stop any active voice recognition and hide mic button on pane close
-    this._stopVoiceRecognition(slotIdx);
-    const micBtn3 = paneEl.querySelector('.terminal-pane-mic');
-    if (micBtn3) { micBtn3.hidden = true; micBtn3.classList.remove('mic-active'); }
-    // Remove any interim transcript overlay
-    const interimOverlay = paneEl.querySelector('.voice-interim-overlay');
-    if (interimOverlay) interimOverlay.remove();
-    const activityEl = document.getElementById(`term-activity-${slotIdx}`);
-    if (activityEl) activityEl.innerHTML = '';
-    const container = document.getElementById(`term-container-${slotIdx}`);
-    if (container) container.innerHTML = '';
+    this._resetTerminalPaneHost(slotIdx);
 
     // If closing the active pane, focus another terminal
     if (this._activeTerminalSlot === slotIdx) {
@@ -16500,22 +16604,70 @@ class CWMApp {
   }
 
   /**
+   * Remove the UI and slot mapping for a speech-recognition instance.
+   * The DOM references are captured when recording starts so cleanup follows
+   * the originating pane instead of whichever session later reuses its slot.
+   */
+  _cleanupVoiceRecognition(recognition) {
+    if (!recognition) return;
+    const micBtn = recognition._cwmMicButton;
+    const interimOverlay = recognition._cwmInterimOverlay;
+    if (micBtn) micBtn.classList.remove('mic-active');
+    if (interimOverlay && interimOverlay.parentNode) interimOverlay.remove();
+    const slotIdx = recognition._cwmSlot;
+    if (this._voiceRecognitions &&
+        this._voiceRecognitions[slotIdx] === recognition) {
+      delete this._voiceRecognitions[slotIdx];
+    }
+  }
+
+  /**
+   * Abort voice input without sending its transcript. Fixed pane slots are
+   * reused by swaps and tab-group caching, so lifecycle moves must discard an
+   * in-flight recording before another TerminalPane can inherit the controls.
+   */
+  _discardVoiceRecognition(slotIdx, expectedPane) {
+    const recognition = this._voiceRecognitions &&
+      this._voiceRecognitions[slotIdx];
+    if (!recognition) return false;
+    if (expectedPane && recognition._cwmTerminalPane !== expectedPane) {
+      return false;
+    }
+    recognition._cwmDiscarded = true;
+    this._cleanupVoiceRecognition(recognition);
+    try {
+      if (typeof recognition.abort === 'function') recognition.abort();
+      else if (typeof recognition.stop === 'function') recognition.stop();
+    } catch (_) {
+      // The mapping/UI were already removed; a closed recognizer needs no
+      // further work.
+    }
+    return true;
+  }
+
+  /**
    * Toggle voice input (speech-to-text) for a terminal pane.
    * Uses the Web Speech API (SpeechRecognition) to capture a single utterance,
    * transcribe it, and send it to the terminal's WebSocket as input.
    * @param {number} slotIdx - The terminal pane slot index
    */
   toggleVoiceInput(slotIdx) {
-    // If already recording for this slot, stop, send accumulated text, and return
-    if (this._voiceRecognitions[slotIdx]) {
-      this._stopVoiceRecognition(slotIdx);
-      return;
-    }
-
     const tp = this.terminalPanes[slotIdx];
     if (!tp) {
       this.showToast('No active terminal in this pane', 'warning');
       return;
+    }
+    const existingRecognition = this._voiceRecognitions[slotIdx];
+    if (existingRecognition) {
+      // A second click only sends when it still belongs to this exact pane and
+      // group. A stale fixed-slot recognizer is discarded, then the current
+      // pane may start a fresh recording.
+      if (existingRecognition._cwmTerminalPane === tp &&
+          existingRecognition._cwmGroupId === this._activeGroupId) {
+        this._stopVoiceRecognition(slotIdx);
+        return;
+      }
+      this._discardVoiceRecognition(slotIdx);
     }
 
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
@@ -16528,9 +16680,14 @@ class CWMApp {
     recognition.continuous = true;    // Keep listening until user clicks stop
     recognition.interimResults = true; // Show partial results while speaking
     recognition.lang = 'en-US';
+    recognition._cwmTerminalPane = tp;
+    recognition._cwmGroupId = this._activeGroupId;
+    recognition._cwmSlot = slotIdx;
+    recognition._cwmDiscarded = false;
 
     const paneEl = document.getElementById(`term-pane-${slotIdx}`);
     const micBtn = paneEl ? paneEl.querySelector('.terminal-pane-mic') : null;
+    recognition._cwmMicButton = micBtn;
 
     // Accumulated final transcript segments (sent when user clicks stop)
     let accumulatedTranscript = '';
@@ -16543,6 +16700,7 @@ class CWMApp {
       interimOverlay.textContent = 'Listening... (click mic to send)';
       paneEl.appendChild(interimOverlay);
     }
+    recognition._cwmInterimOverlay = interimOverlay;
 
     // Update the overlay with accumulated + interim text
     const updateOverlay = (interim) => {
@@ -16553,6 +16711,7 @@ class CWMApp {
 
     // Handle speech recognition results (both interim and final)
     recognition.onresult = (event) => {
+      if (recognition._cwmDiscarded) return;
       let interimTranscript = '';
 
       for (let i = event.resultIndex; i < event.results.length; i++) {
@@ -16570,6 +16729,7 @@ class CWMApp {
 
     // Handle recognition start
     recognition.onstart = () => {
+      if (recognition._cwmDiscarded) return;
       if (micBtn) micBtn.classList.add('mic-active');
       this.showToast('Listening... click mic again to send', 'info');
     };
@@ -16578,21 +16738,32 @@ class CWMApp {
     // (silence timeout, network drop, etc.). If the user didn't explicitly stop,
     // restart automatically so listening continues until the button is pressed.
     recognition.onend = () => {
+      const stillMapped = this._voiceRecognitions[slotIdx] === recognition;
+      const ownerStillLive = this._activeGroupId === recognition._cwmGroupId &&
+        this.terminalPanes.includes(tp);
+      if (recognition._cwmDiscarded || !stillMapped || !ownerStillLive) {
+        this._cleanupVoiceRecognition(recognition);
+        return;
+      }
       if (recognition._cwmUserStopped) {
         // User clicked stop: send accumulated transcript and clean up
-        if (micBtn) micBtn.classList.remove('mic-active');
-        if (interimOverlay && interimOverlay.parentNode) interimOverlay.remove();
-        delete this._voiceRecognitions[slotIdx];
+        this._cleanupVoiceRecognition(recognition);
 
         const text = accumulatedTranscript.trim();
         if (text) {
-          const currentTp = this.terminalPanes[slotIdx];
-          if (!currentTp || !currentTp.ws || currentTp.ws.readyState !== WebSocket.OPEN) {
+          if (!tp.ws || tp.ws.readyState !== WebSocket.OPEN) {
             this.showToast('Terminal not connected, voice input discarded', 'warning');
           } else {
             // Clean up punctuation and grammar before sending
             this._punctuateVoiceText(text).then(cleaned => {
-              currentTp.ws.send(JSON.stringify({ type: 'input', data: cleaned + '\n' }));
+              const canStillSend = this._activeGroupId === recognition._cwmGroupId &&
+                this.terminalPanes.includes(tp) &&
+                tp.ws && tp.ws.readyState === WebSocket.OPEN;
+              if (!canStillSend) {
+                this.showToast('Pane changed, voice input discarded', 'warning');
+                return;
+              }
+              tp.ws.send(JSON.stringify({ type: 'input', data: cleaned + '\n' }));
               this.showToast('Voice input sent', 'success');
             });
           }
@@ -16603,9 +16774,7 @@ class CWMApp {
           recognition.start();
         } catch (_) {
           // If restart fails, clean up gracefully
-          if (micBtn) micBtn.classList.remove('mic-active');
-          if (interimOverlay && interimOverlay.parentNode) interimOverlay.remove();
-          delete this._voiceRecognitions[slotIdx];
+          this._cleanupVoiceRecognition(recognition);
         }
       }
     };
@@ -16624,9 +16793,7 @@ class CWMApp {
       const msg = errorMessages[event.error] || `Speech recognition error: ${event.error}`;
       this.showToast(msg, 'error');
       recognition._cwmUserStopped = true; // Prevent auto-restart on fatal errors
-      if (micBtn) micBtn.classList.remove('mic-active');
-      if (interimOverlay && interimOverlay.parentNode) interimOverlay.remove();
-      delete this._voiceRecognitions[slotIdx];
+      this._cleanupVoiceRecognition(recognition);
     };
 
     // Store the recognition instance and start listening
@@ -16643,6 +16810,12 @@ class CWMApp {
   _stopVoiceRecognition(slotIdx) {
     const recognition = this._voiceRecognitions[slotIdx];
     if (recognition) {
+      const currentPane = this.terminalPanes[slotIdx];
+      if (recognition._cwmTerminalPane !== currentPane ||
+          recognition._cwmGroupId !== this._activeGroupId) {
+        this._discardVoiceRecognition(slotIdx);
+        return;
+      }
       // Mark as user-stopped so onend sends accumulated text instead of restarting.
       // We use stop() (not abort()) so any pending results still fire before onend.
       recognition._cwmUserStopped = true;
@@ -16650,7 +16823,7 @@ class CWMApp {
         recognition.stop();
       } catch (_) {
         // Fallback: clean up directly if stop() throws
-        delete this._voiceRecognitions[slotIdx];
+        this._cleanupVoiceRecognition(recognition);
       }
     }
   }
@@ -16681,6 +16854,196 @@ class CWMApp {
   }
 
   /**
+   * Return a reusable fixed pane host to a complete, inert empty state.
+   * This is the single lifecycle reset for close, fatal error, group cache,
+   * and moves; it clears every slot-owned control/view/timer without touching
+   * any TerminalPane that a caller may already have detached into a cache.
+   */
+  _resetTerminalPaneHost(slotIdx, options = {}) {
+    const paneEl = document.getElementById(`term-pane-${slotIdx}`);
+    if (!paneEl) return false;
+    const clearTerminal = options.clearTerminal !== false;
+
+    this._discardVoiceRecognition(slotIdx);
+    this._clearPaneViewHost(slotIdx);
+
+    if (window.SchedulePopover && window.SchedulePopover.anchor &&
+        paneEl.contains(window.SchedulePopover.anchor)) {
+      window.SchedulePopover.close();
+    }
+
+    paneEl.classList.remove(
+      'terminal-pane-active',
+      'pane-expanded-stage1',
+      'pane-expanded-stage2',
+      'pane-nav-pulse',
+      'terminal-pane-dragging',
+      'drag-over',
+      'terminal-pane-loading',
+      'terminal-pane-done',
+      'mobile-active'
+    );
+      paneEl.classList.add('terminal-pane-empty');
+      paneEl.classList.remove('mobile-active');
+    paneEl.removeAttribute('data-provider');
+    delete paneEl.dataset.attentionState;
+    delete paneEl.dataset.needsInput;
+
+    const titleEl = paneEl.querySelector('.terminal-pane-title');
+    if (titleEl) titleEl.textContent = 'Drop a session here';
+    const headerEl = paneEl.querySelector('.terminal-pane-header');
+    if (headerEl) {
+      headerEl.classList.remove('attention-state');
+      delete headerEl.dataset.attentionState;
+      delete headerEl.dataset.needsInput;
+    }
+    const pillEl = paneEl.querySelector('.pane-provider-pill');
+    if (pillEl) {
+      pillEl.hidden = true;
+      pillEl.textContent = '';
+      pillEl.removeAttribute('data-provider');
+    }
+    for (const selector of [
+      '.terminal-pane-close',
+      '.terminal-pane-upload',
+      '.terminal-pane-expand',
+      '.terminal-pane-collapse',
+      '.terminal-pane-mic',
+      '.terminal-pane-pinnedoc',
+    ]) {
+      const control = paneEl.querySelector(selector);
+      if (control) control.hidden = true;
+    }
+    const expandBtn = paneEl.querySelector('.terminal-pane-expand');
+    if (expandBtn) {
+      expandBtn.classList.remove(
+        'terminal-pane-expand-stage1',
+        'terminal-pane-expand-stage2'
+      );
+      expandBtn.title = 'Expand pane';
+    }
+    const micBtn = paneEl.querySelector('.terminal-pane-mic');
+    if (micBtn) micBtn.classList.remove('mic-active');
+    const scheduleBtn = paneEl.querySelector('.terminal-pane-schedule');
+    if (scheduleBtn) {
+      scheduleBtn.hidden = true;
+      const badge = scheduleBtn.querySelector('.pane-schedule-count');
+      if (badge) { badge.textContent = ''; badge.hidden = true; }
+    }
+    const pinCount = paneEl.querySelector('.pane-pin-count');
+    if (pinCount) pinCount.textContent = '';
+    const interimOverlay = paneEl.querySelector('.voice-interim-overlay');
+    if (interimOverlay) interimOverlay.remove();
+    const mobileInputRow = paneEl.querySelector('.terminal-mobile-input-row');
+    if (mobileInputRow) mobileInputRow.classList.remove('active');
+    const mobileInput = paneEl.querySelector('.mobile-type-input');
+    if (mobileInput) {
+      mobileInput.value = '';
+      if (document.activeElement === mobileInput &&
+          typeof mobileInput.blur === 'function') {
+        mobileInput.blur();
+      }
+    }
+    const keyboardBtn = paneEl.querySelector('.toolbar-keyboard');
+    if (keyboardBtn) {
+      keyboardBtn.classList.remove('toolbar-active');
+      keyboardBtn.textContent = '\u2328 Type';
+    }
+    const activityEl = document.getElementById(`term-activity-${slotIdx}`);
+    if (activityEl) {
+      activityEl.innerHTML = '';
+      delete activityEl.dataset.activityKey;
+    }
+    const container = document.getElementById(`term-container-${slotIdx}`);
+    if (container) {
+      container.hidden = false;
+      if (clearTerminal) container.replaceChildren();
+    }
+    if (typeof this._renderCodexStatusStrip === 'function') {
+      this._renderCodexStatusStrip(slotIdx);
+    }
+    return true;
+  }
+
+  /**
+   * Rebind a live TerminalPane and its provider chrome to a fixed grid slot.
+   *
+   * @param {number} slotIdx - Destination pane slot.
+   * @param {TerminalPane} tp - Live pane now occupying that slot.
+   * @returns {boolean} true when the destination host exists.
+   */
+  _syncTerminalPaneHost(slotIdx, tp) {
+    if (!tp) return false;
+    const paneEl = document.getElementById(`term-pane-${slotIdx}`);
+    const containerId = `term-container-${slotIdx}`;
+    const container = document.getElementById(containerId);
+    if (!paneEl || !container) return false;
+
+    if (typeof tp.rebindHost === 'function') {
+      tp.rebindHost(containerId);
+    } else {
+      // Backward-compatible fallback for a mixed cached instance created
+      // before TerminalPane.rebindHost was available.
+      tp.containerId = containerId;
+      tp.paneEl = paneEl;
+      if (typeof tp._installSelectModeInterceptor === 'function') {
+        tp._installSelectModeInterceptor();
+      }
+      if (typeof tp._injectCopyControls === 'function') tp._injectCopyControls();
+    }
+
+    const provider = (tp.spawnOpts && tp.spawnOpts.provider) ||
+      tp._providerId || 'claude'; /* gsd:provider-literal-allowed */
+    paneEl.hidden = false;
+    paneEl.classList.remove('terminal-pane-empty');
+    const titleEl = paneEl.querySelector('.terminal-pane-title');
+    if (titleEl) titleEl.textContent = tp.sessionName || tp.sessionId;
+    paneEl.dataset.provider = provider;
+    const pillEl = paneEl.querySelector('.pane-provider-pill');
+    if (pillEl) {
+      pillEl.dataset.provider = provider;
+      const registered = this._getProviderById ? this._getProviderById(provider) : null;
+      pillEl.textContent = (registered && registered.displayName) ||
+        (provider ? provider.charAt(0).toUpperCase() + provider.slice(1) : '');
+      pillEl.hidden = !provider;
+    }
+    const closeBtn = paneEl.querySelector('.terminal-pane-close');
+    if (closeBtn) closeBtn.hidden = false;
+    const uploadBtn = paneEl.querySelector('.terminal-pane-upload');
+    if (uploadBtn) uploadBtn.hidden = false;
+    const scheduleBtn = paneEl.querySelector('.terminal-pane-schedule');
+    if (scheduleBtn) scheduleBtn.hidden = false;
+    const micBtn = paneEl.querySelector('.terminal-pane-mic');
+    if (micBtn) micBtn.hidden = !this._speechRecognitionAvailable;
+    const expandBtn = paneEl.querySelector('.terminal-pane-expand');
+    if (expandBtn) expandBtn.hidden = false;
+    const collapseBtn = paneEl.querySelector('.terminal-pane-collapse');
+    if (collapseBtn) collapseBtn.hidden = true;
+    container.hidden = !!paneEl.dataset.viewType;
+    if (typeof this._renderCodexStatusStrip === 'function') {
+      this._renderCodexStatusStrip(slotIdx);
+    }
+    if (this._attentionState &&
+        typeof this._applyAttentionStateToDom === 'function') {
+      const state = tp._needsInput
+        ? 'needs-input'
+        : this._attentionStateForSession(tp.sessionId);
+      this._applyAttentionStateToDom(tp.sessionId, state);
+    }
+    const headerEl = paneEl.querySelector('.terminal-pane-header');
+    if (headerEl) {
+      headerEl.dataset.needsInput = tp._needsInput ? 'true' : 'false';
+    }
+    if (typeof this.updatePaneActivity === 'function') {
+      this.updatePaneActivity(slotIdx, tp._currentActivity || null);
+    }
+    if (this.state && typeof this._refreshPanePin === 'function') {
+      Promise.resolve(this._refreshPanePin(slotIdx)).catch(() => {});
+    }
+    return true;
+  }
+
+  /**
    * Swap two terminal panes in the grid.
    * Swaps the xterm DOM nodes and the terminalPanes array entries.
    * If one slot is empty, it becomes a move instead of a swap.
@@ -16689,6 +17052,23 @@ class CWMApp {
     console.log(`[DnD] Swapping panes: slot ${srcSlot} <-> slot ${dstSlot}`);
     const srcTp = this.terminalPanes[srcSlot];
     const dstTp = this.terminalPanes[dstSlot];
+    // Voice capture and structured views are fixed-host resources. End them
+    // before the TerminalPane identities move so no transcript, timer, or
+    // late async view render can remain attached to the old slot.
+    [srcSlot, dstSlot].forEach(slot => {
+      const tp = this.terminalPanes[slot];
+      if (tp && typeof tp.blur === 'function') tp.blur();
+      this._resetTerminalPaneHost(slot, { clearTerminal: false });
+    });
+    // Host rebinding can focus a mobile type-mode textarea, whose focusin
+    // listener mutates _activeTerminalSlot while the swap is half complete.
+    // Remember the active TerminalPane itself before any DOM/listener work so
+    // the final active slot follows that immutable owner, not an intermediate
+    // focus side effect.
+    const activeTpBeforeSwap = Number.isInteger(this._activeTerminalSlot)
+      ? this.terminalPanes[this._activeTerminalSlot]
+      : null;
+    const activeSlotBeforeSwap = this._activeTerminalSlot;
 
     // Swap in the array
     this.terminalPanes[srcSlot] = dstTp;
@@ -16724,27 +17104,51 @@ class CWMApp {
           }
         }
       } else {
-        // Empty pane - reset to drop target
-        paneEl.classList.remove('terminal-pane-active');
-        paneEl.classList.add('terminal-pane-empty');
-        if (titleEl) titleEl.textContent = 'Drop a session here';
-        if (closeBtn) closeBtn.hidden = true;
-        if (uploadBtnEl) uploadBtnEl.hidden = true;
-        if (scheduleBtnEl) {
-          scheduleBtnEl.hidden = true;
-          const badge = scheduleBtnEl.querySelector('.pane-schedule-count');
-          if (badge) { badge.textContent = ''; badge.hidden = true; }
-        }
-        if (micBtnEl) { micBtnEl.hidden = true; micBtnEl.classList.remove('mic-active'); }
-        if (container) container.innerHTML = '';
+        // Empty pane - reset every slot-owned control/view/timer.
+        this._resetTerminalPaneHost(slot);
       }
     });
 
+    // Moving only tp.term.element leaves every slot-owned listener, Select
+    // control, resize observer, focus lookup, and provider tag pointed at the
+    // old host. Rebind both entries after their xterm DOM has moved.
+    [srcSlot, dstSlot].forEach(slot => {
+      const tp = this.terminalPanes[slot];
+      if (tp) this._syncTerminalPaneHost(slot, tp);
+    });
+
     // Update active pane tracking
-    if (this._activeTerminalSlot === srcSlot) {
-      this._activeTerminalSlot = dstSlot;
-    } else if (this._activeTerminalSlot === dstSlot) {
-      this._activeTerminalSlot = srcSlot;
+    const relocatedActiveSlot = activeTpBeforeSwap
+      ? this.terminalPanes.indexOf(activeTpBeforeSwap)
+      : -1;
+    this._activeTerminalSlot = relocatedActiveSlot >= 0
+      ? relocatedActiveSlot
+      : activeSlotBeforeSwap;
+    [srcSlot, dstSlot].forEach(slot => {
+      const paneEl = document.getElementById(`term-pane-${slot}`);
+      if (paneEl) paneEl.classList.remove('terminal-pane-active');
+    });
+    const activePaneEl = Number.isInteger(this._activeTerminalSlot)
+      ? document.getElementById(`term-pane-${this._activeTerminalSlot}`)
+      : null;
+    if (activePaneEl && this.terminalPanes[this._activeTerminalSlot]) {
+      activePaneEl.classList.add('terminal-pane-active');
+    }
+    this.terminalPanes.forEach((tp, index) => {
+      if (!tp) return;
+      if (typeof tp.setFocused === 'function') {
+        tp.setFocused(index === this._activeTerminalSlot);
+      }
+      if (index !== this._activeTerminalSlot &&
+          typeof tp.blur === 'function') {
+        tp.blur();
+      }
+    });
+    const activeTpAfterSwap = Number.isInteger(this._activeTerminalSlot)
+      ? this.terminalPanes[this._activeTerminalSlot]
+      : null;
+    if (activeTpAfterSwap && typeof activeTpAfterSwap.focus === 'function') {
+      activeTpAfterSwap.focus();
     }
 
     // Update grid layout and refit terminals
@@ -17050,6 +17454,105 @@ class CWMApp {
   /* ═══════════════════════════════════════════════════════════
      TERMINAL FOCUS & RESIZE
      ═══════════════════════════════════════════════════════════ */
+
+  /**
+   * Resolve the TerminalPane that owns the actual pointer target.
+   *
+   * @param {number} slotIdx - Fixed grid slot under the pointer.
+   * @param {Event} event - Pointer/context-menu event.
+   * @returns {TerminalPane|null} Live event owner or the slot fallback.
+   */
+  _terminalPaneFromPointerEvent(slotIdx, event) {
+    const slotPane = this.terminalPanes && this.terminalPanes[slotIdx];
+    const eventTarget = event && event.target;
+    if (!eventTarget) return slotPane || null;
+
+    const xtermRoot = eventTarget.closest
+      ? eventTarget.closest('.xterm')
+      : null;
+    if (xtermRoot && xtermRoot.__cwmTerminalPane) {
+      return xtermRoot.__cwmTerminalPane;
+    }
+
+    if (this.terminalPanes) {
+      const mountedPane = this.terminalPanes.find(candidate =>
+        candidate && candidate.term && candidate.term.element &&
+        (candidate.term.element === eventTarget ||
+          candidate.term.element.contains(eventTarget)));
+      if (mountedPane) return mountedPane;
+    }
+    return slotPane || null;
+  }
+
+  /**
+   * Focus a pane from its ancestor capture-phase pointer listener.
+   *
+   * A selected-text right click is intentionally different from an ordinary
+   * pane click. The pane-level capture listener runs before TerminalPane's
+   * descendant capture listener. Calling setActiveTerminalPane here can
+   * refocus/refit xterm and clear its selection before the descendant
+   * right-button guard or the later contextmenu handler can read it. The
+   * visible result is exactly what the live GUI exposed: highlighted text
+   * disappears, the menu omits Copy, and a subsequent Ctrl+C has no selection.
+   *
+   * Preserve the existing xterm selection on right-button mousedown and let
+   * TerminalPane's capture guard stop the event before it reaches the
+   * mouse-reporting TUI. Normal left clicks and unselected right clicks keep
+   * the existing focus behavior.
+   *
+   * @param {number} slotIdx - Terminal pane slot.
+   * @param {MouseEvent|TouchEvent} event - Captured pointer event.
+   * @returns {boolean} true when focus ran, false when skipped or unavailable.
+   */
+  _focusTerminalPaneFromPointer(slotIdx, event) {
+    const tp = this._terminalPaneFromPointerEvent(slotIdx, event);
+    if (!tp) return false;
+
+    const copySelection = typeof tp.getCopySelection === 'function'
+      ? tp.getCopySelection()
+      : {
+          hasSelection: !!(tp.term && typeof tp.term.hasSelection === 'function' &&
+            tp.term.hasSelection()),
+        };
+    const selectedRightPress =
+      event && event.type === 'mousedown' && event.button === 2 &&
+      copySelection.hasSelection;
+    if (selectedRightPress) {
+      // Stop the right-button press here, at the first pane capture listener.
+      // TerminalPane normally repeats this guard on the terminal container,
+      // but a pane that has been reordered or restored from the live group
+      // cache may still have an older container binding. Letting the press
+      // continue in that state allows xterm to report it to the mouse-aware
+      // TUI, whose redraw clears the selection before `contextmenu` runs.
+      //
+      // Do not preventDefault: the separate contextmenu event must still
+      // reach showTerminalContextMenu and expose the selected-text actions.
+      if (typeof event.stopPropagation === 'function') event.stopPropagation();
+      return false;
+    }
+
+    // The pane capture listener also sees the synthetic Shift+mousedown that
+    // Select mode re-dispatches. Re-activating an already-active pane for the
+    // raw event and again for its clone calls focus()+activate() twice; activate
+    // can reassert PTY geometry, redraw a mouse-aware TUI, and race the xterm
+    // selection that the same gesture is trying to create. A normal xterm
+    // mousedown already keeps its textarea focused, so an active owner needs no
+    // app-level focus work. Inactive panes still activate exactly once.
+    const ownerSlot = this.terminalPanes
+      ? this.terminalPanes.indexOf(tp)
+      : -1;
+    const focusSlot = ownerSlot >= 0 ? ownerSlot : slotIdx;
+    const eventTarget = event && event.target;
+    const onTerminalSurface = !!(eventTarget && eventTarget.closest &&
+      eventTarget.closest('.xterm'));
+    if (this._activeTerminalSlot === focusSlot &&
+        (onTerminalSurface || (event && event.__cwmSelSynthetic))) {
+      return false;
+    }
+
+    this.setActiveTerminalPane(focusSlot);
+    return true;
+  }
 
   /**
    * Set the active terminal pane - blurs all others, focuses target, highlights it.
@@ -17816,9 +18319,18 @@ class CWMApp {
       return;
     }
 
-    const activePanes = this.terminalPanes.map((tp, i) => tp ? { idx: i, tp } : null).filter(Boolean);
+    const activePanes = [];
+    for (let i = 0; i < CWMApp.MAX_PANES; i++) {
+      const tp = this.terminalPanes[i];
+      const mirror = this._mirrorPanes && this._mirrorPanes[i];
+      if (tp || mirror) activePanes.push({ idx: i, tp, mirror });
+    }
 
     if (activePanes.length === 0) {
+      for (let i = 0; i < CWMApp.MAX_PANES; i++) {
+        const pane = document.getElementById(`term-pane-${i}`);
+        if (pane) pane.classList.remove('mobile-active');
+      }
       strip.hidden = true;
       return;
     }
@@ -17826,24 +18338,35 @@ class CWMApp {
     strip.hidden = false;
 
     // Find which pane is currently mobile-active
-    let activeIdx = activePanes[0].idx;
-    for (const p of activePanes) {
-      const el = document.getElementById(`term-pane-${p.idx}`);
-      if (el && el.classList.contains('mobile-active')) {
-        activeIdx = p.idx;
-        break;
+    const requestedActive = activePanes.some(
+      p => p.idx === this._activeTerminalSlot
+    );
+    let activeIdx = requestedActive
+      ? this._activeTerminalSlot
+      : activePanes[0].idx;
+    if (!requestedActive) {
+      for (const p of activePanes) {
+        const el = document.getElementById(`term-pane-${p.idx}`);
+        if (el && el.classList.contains('mobile-active')) {
+          activeIdx = p.idx;
+          break;
+        }
       }
     }
 
     strip.innerHTML = activePanes.map(p => {
       const isActive = p.idx === activeIdx;
-      const terminalName = this.escapeHtml(p.tp.sessionName || 'Terminal');
+      const paneName = this.escapeHtml(
+        p.tp
+          ? (p.tp.sessionName || 'Terminal')
+          : (p.mirror.title || p.mirror.providerSessionId || 'Mirror')
+      );
       return `<div class="terminal-tab-item${isActive ? ' active' : ''}" data-slot="${p.idx}">
         <button type="button" class="terminal-tab${isActive ? ' active' : ''}" data-slot="${p.idx}">
-          ${terminalName}
+          ${paneName}
         </button>
         <button type="button" class="terminal-tab-close" data-slot="${p.idx}"
-          title="Close terminal" aria-label="Close ${terminalName} terminal">&times;</button>
+          title="Close pane" aria-label="Close ${paneName} pane">&times;</button>
       </div>`;
     }).join('') + `<button class="terminal-tab terminal-tab-add" title="Open terminal">+</button>`;
 
@@ -17880,7 +18403,12 @@ class CWMApp {
     strip.querySelectorAll('.terminal-tab-close').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        this.closeTerminalPane(parseInt(btn.dataset.slot, 10));
+        const slot = parseInt(btn.dataset.slot, 10);
+        if (this.terminalPanes[slot]) {
+          this.closeTerminalPane(slot);
+        } else if (this._mirrorPanes && this._mirrorPanes[slot]) {
+          this.restoreTerminalInPane(slot);
+        }
         this.updateTerminalTabs();
       });
     });
@@ -17951,18 +18479,33 @@ class CWMApp {
       });
     }
 
-    // Reset keyboard toggle button to match new pane's input mode
-    if (tp && tp._isMobile && tp._isMobile()) {
-      const isTypeMode = !!tp._mobileTypeMode;
-      document.querySelectorAll('.toolbar-keyboard').forEach(kb => {
-        kb.classList.toggle('toolbar-active', isTypeMode);
-        kb.textContent = isTypeMode ? '\u2328 Typing' : '\u2328 Type';
-      });
+    // The dedicated input row is the per-pane source of truth. Do not mirror
+    // one pane's state onto every fixed-slot toolbar.
+    if (activeEl) {
+      const mobileToolbar = activeEl.querySelector('.terminal-mobile-toolbar');
+      const inputRow = activeEl.querySelector('.terminal-mobile-input-row');
+      const keyboardBtn = activeEl.querySelector('.toolbar-keyboard');
+      if (mobileToolbar) mobileToolbar.hidden = !tp;
+      if (inputRow) {
+        inputRow.hidden = !tp;
+        if (!tp) inputRow.classList.remove('active');
+      }
+      const isTyping = !!(inputRow && inputRow.classList.contains('active'));
+      if (keyboardBtn) {
+        keyboardBtn.classList.toggle('toolbar-active', isTyping);
+        keyboardBtn.textContent = isTyping ? '\u2328 Typing' : '\u2328 Type';
+      }
     }
 
     // Update pane indicator dots
     if (this.els.terminalTabStrip) {
-      const activePanes = this.terminalPanes.map((tp, i) => tp ? i : -1).filter(i => i !== -1);
+      const activePanes = [];
+      for (let i = 0; i < CWMApp.MAX_PANES; i++) {
+        if (this.terminalPanes[i] ||
+            (this._mirrorPanes && this._mirrorPanes[i])) {
+          activePanes.push(i);
+        }
+      }
       const dots = this.els.terminalTabStrip.querySelectorAll('.indicator-dot');
       dots.forEach((dot, i) => {
         dot.classList.toggle('active', activePanes[i] === slotIdx);
@@ -19300,9 +19843,6 @@ class CWMApp {
           const opts = { ...(p.spawnOpts || {}) };
           if (p.provider && !opts.provider) opts.provider = p.provider;
           this.openTerminalInPane(p.slot, p.sessionId, p.sessionName || 'Terminal', opts);
-          if (p.viewType) {
-            setTimeout(() => this.openViewInPane(p.slot, p.viewType, p.viewData || {}), 100);
-          }
         } else if (p.viewType === 'mirror' && !p.sessionId && !this._isSlotOccupied(p.slot)) {
           // Issue #10 Phase 4: standalone mirror pane (no PTY session).
           // Re-open from the persisted descriptor; openMirrorInSlot owns
@@ -19658,10 +20198,38 @@ class CWMApp {
     // so we can reattach instantly when switching back.
     const prevGroupId = this._activeGroupId;
     if (prevGroupId) {
-      const cached = { panes: new Array(CWMApp.MAX_PANES).fill(null), domFragments: new Array(CWMApp.MAX_PANES).fill(null) };
+      const activeSlotForCache = this._activeTerminalSlot;
+      const cached = {
+        panes: new Array(CWMApp.MAX_PANES).fill(null),
+        domFragments: new Array(CWMApp.MAX_PANES).fill(null),
+        activePane: Number.isInteger(activeSlotForCache)
+          ? this.terminalPanes[activeSlotForCache] || null
+          : null,
+        activeSlot: Number.isInteger(activeSlotForCache)
+          ? activeSlotForCache
+          : null,
+      };
       for (let i = 0; i < CWMApp.MAX_PANES; i++) {
         if (this.terminalPanes[i]) {
           cached.panes[i] = this.terminalPanes[i];
+          if (typeof cached.panes[i].setFocused === 'function') {
+            cached.panes[i].setFocused(false);
+          }
+          // Invalidate any unconditional activation queued when this pane was
+          // first opened. An A -> B -> A cycle may complete before that rAF;
+          // mounting may still proceed, but it must not override A's restored
+          // remembered active pane.
+          cached.panes[i]._mountActivationGeneration =
+            (cached.panes[i]._mountActivationGeneration || 0) + 1;
+          if (typeof cached.panes[i].blur === 'function') {
+            cached.panes[i].blur();
+          }
+          // Static grid slots are shared by every tab group. Release this
+          // pane's Select UI, pointer/touch capture, focus host, and resize
+          // observation before another group's TerminalPane occupies them.
+          if (typeof cached.panes[i].detachHostBindings === 'function') {
+            cached.panes[i].detachHostBindings();
+          }
           // Detach xterm DOM into a fragment (preserves WebSocket + state)
           const termContainer = document.getElementById(`term-container-${i}`);
           if (termContainer && termContainer.childNodes.length > 0) {
@@ -19671,38 +20239,10 @@ class CWMApp {
           }
         }
         this.terminalPanes[i] = null;
-        // Issue #10 Phase 4: standalone mirror panes are not cacheable like
-        // xterm DOM (the subscription is server-side state, not a canvas).
-        // Dispose on switch-away; saveCurrentGroupPanes() above already
-        // persisted the descriptor, and _restoreGroupMirrorPanes re-opens
-        // it (idempotent, fresh history) when this group activates again.
-        if (this._mirrorPanes[i]) {
-          try { this._mirrorPanes[i].dispose(); } catch (_) { /* already gone */ }
-          delete this._mirrorPanes[i];
-          const mirrorViewContainer = document.getElementById(`pane-view-${i}`);
-          if (mirrorViewContainer) { mirrorViewContainer.hidden = true; mirrorViewContainer.replaceChildren(); }
-        }
-        // Reset pane DOM to empty visual state
-        const paneEl = document.getElementById(`term-pane-${i}`);
-        if (paneEl) {
-          paneEl.classList.add('terminal-pane-empty');
-          const header = paneEl.querySelector('.terminal-pane-title');
-          if (header) header.textContent = 'Drop a session here';
-          const closeBtn = paneEl.querySelector('.terminal-pane-close');
-          if (closeBtn) closeBtn.hidden = true;
-          const uploadBtnG = paneEl.querySelector('.terminal-pane-upload');
-          if (uploadBtnG) uploadBtnG.hidden = true;
-          // Clear stale mirror view chrome so the incoming group's slot
-          // starts clean (only when the slot hosted a standalone mirror).
-          if (paneEl.dataset.viewType === 'mirror') {
-            const mBadge = paneEl.querySelector('.pane-view-badge');
-            const mBack = paneEl.querySelector('.pane-view-back');
-            if (mBadge) mBadge.hidden = true;
-            if (mBack) mBack.hidden = true;
-            delete paneEl.dataset.viewType;
-            delete paneEl.dataset.viewData;
-          }
-        }
+        // Standalone mirrors, structured views, voice capture, timers, and
+        // all chrome are fixed-host state. The descriptor was persisted by
+        // saveCurrentGroupPanes(), so reset the shared slot completely.
+        this._resetTerminalPaneHost(i);
       }
       this._groupPaneCache[prevGroupId] = cached;
     }
@@ -19711,6 +20251,19 @@ class CWMApp {
 
     // ── Restore this tab group's split ratios (or reset to equal) ──
     const targetGroup = this._tabGroups.find(g => g.id === groupId);
+    // openTerminalInPane persists after each fresh attach. Keep an immutable
+    // copy of the incoming descriptors so those saves cannot erase structured
+    // views or mirrors before their owners are restored below.
+    const targetPaneRecords = targetGroup && Array.isArray(targetGroup.panes)
+      ? targetGroup.panes.map(record => ({
+          ...record,
+          spawnOpts: { ...((record && record.spawnOpts) || {}) },
+          viewData: { ...((record && record.viewData) || {}) },
+        }))
+      : [];
+    const restoreGroup = targetGroup
+      ? { ...targetGroup, panes: targetPaneRecords }
+      : null;
     if (targetGroup && targetGroup.gridColSizes) {
       this._gridColSizes = [...targetGroup.gridColSizes];
     } else {
@@ -19724,6 +20277,8 @@ class CWMApp {
 
     // ── Restore target group: try cache first, fall back to fresh connections ──
     const cached = this._groupPaneCache[groupId];
+    let preferredActiveSlot = null;
+    let rememberedActiveSlot = null;
     if (cached) {
       // Reattach cached panes instantly (no reconnection needed)
       for (let i = 0; i < CWMApp.MAX_PANES; i++) {
@@ -19744,12 +20299,33 @@ class CWMApp {
           // Reattach xterm DOM, or re-render placeholder for disconnected panes
           if (cached.domFragments[i]) {
             const termContainer = document.getElementById(`term-container-${i}`);
-            if (termContainer) termContainer.appendChild(cached.domFragments[i]);
+            if (termContainer) {
+              termContainer.appendChild(cached.domFragments[i]);
+              this._syncTerminalPaneHost(i, cached.panes[i]);
+            }
           } else if (cached.panes[i].sessionId) {
-            // Cached pane had no DOM fragment (was disconnected), reconnect directly
-            this.openTerminalInPane(i, cached.panes[i].sessionId, cached.panes[i].sessionName, cached.panes[i].spawnOpts);
+            // The pane may have been switched away during its one-frame
+            // deferred mount. Reuse the same TerminalPane identity and mount
+            // it only if this group still owns it when the next frame runs.
+            this._syncTerminalPaneHost(i, cached.panes[i]);
+            if (!cached.panes[i].term) {
+              this._mountTerminalPaneOnNextFrame(
+                cached.panes[i],
+                groupId,
+                'if-active'
+              );
+            }
           }
         }
+      }
+      const activePaneSlot = cached.activePane
+        ? this.terminalPanes.indexOf(cached.activePane)
+        : -1;
+      if (activePaneSlot >= 0) {
+        preferredActiveSlot = activePaneSlot;
+      }
+      if (Number.isInteger(cached.activeSlot)) {
+        rememberedActiveSlot = cached.activeSlot;
       }
       delete this._groupPaneCache[groupId];
       // Recalculate grid layout for restored pane count, then refit.
@@ -19759,6 +20335,7 @@ class CWMApp {
       // same-size restores produce blank canvases without an explicit refresh.
       this.updateTerminalGridLayout();
       requestAnimationFrame(() => {
+        if (this._activeGroupId !== groupId) return;
         for (let j = 0; j < CWMApp.MAX_PANES; j++) {
           const tp = this.terminalPanes[j];
           if (tp && tp.term) {
@@ -19771,18 +20348,27 @@ class CWMApp {
         // the cached pane's own fits were suppressed by the isConnected
         // guard. Fall back to the first restored pane when the remembered
         // active slot is empty in this group.
-        const restoredTp = (this._activeTerminalSlot !== null && this._activeTerminalSlot !== undefined && this.terminalPanes[this._activeTerminalSlot])
+        const selectedSlotOccupied =
+          Number.isInteger(this._activeTerminalSlot) &&
+          this._isSlotOccupied(this._activeTerminalSlot);
+        const restoredTp = selectedSlotOccupied
           ? this.terminalPanes[this._activeTerminalSlot]
           : this.terminalPanes.find(p => p);
         if (restoredTp && typeof restoredTp.activate === 'function') restoredTp.activate();
       });
     } else {
       // No cache, create fresh connections (first time opening this group)
-      const group = this._tabGroups.find(g => g.id === groupId);
-      if (group && group.panes) {
-        group.panes.forEach(p => {
+      if (restoreGroup && restoreGroup.panes) {
+        restoreGroup.panes.forEach(p => {
           if (p.sessionId && !this.terminalPanes[p.slot]) {
-            this.openTerminalInPane(p.slot, p.sessionId, p.sessionName || 'Terminal', p.spawnOpts || {});
+            const opts = { ...(p.spawnOpts || {}) };
+            if (p.provider && !opts.provider) opts.provider = p.provider;
+            this.openTerminalInPane(
+              p.slot,
+              p.sessionId,
+              p.sessionName || 'Terminal',
+              opts
+            );
           }
         });
       }
@@ -19792,15 +20378,60 @@ class CWMApp {
     // Runs after BOTH restore branches: the pane cache only carries
     // TerminalPane instances (mirror subscriptions were disposed on
     // switch-away), so mirrors always restore from their descriptors.
-    this._restoreGroupMirrorPanes(this._tabGroups.find(g => g.id === groupId));
+    this._restoreGroupMirrorPanes(restoreGroup);
+    if (preferredActiveSlot === null &&
+        Number.isInteger(rememberedActiveSlot) &&
+        this._isSlotOccupied(rememberedActiveSlot)) {
+      preferredActiveSlot = rememberedActiveSlot;
+    }
 
     // Re-point the active-slot suppression at a pane that actually exists
     // in the NEW group (runs after both the cached and fresh branches).
     // Without this, onTerminalIdle compared incoming idle events against
     // the PREVIOUS group's slot index, so every pane in the restored group
     // looked "inactive" and could toast even while fully on screen.
-    const firstFilledSlot = this.terminalPanes.findIndex(p => p);
-    this._activeTerminalSlot = firstFilledSlot !== -1 ? firstFilledSlot : null;
+    let firstFilledSlot = -1;
+    for (let i = 0; i < CWMApp.MAX_PANES; i++) {
+      if (this._isSlotOccupied(i)) {
+        firstFilledSlot = i;
+        break;
+      }
+    }
+    this._activeTerminalSlot = preferredActiveSlot !== null
+      ? preferredActiveSlot
+      : (firstFilledSlot !== -1 ? firstFilledSlot : null);
+    for (let i = 0; i < CWMApp.MAX_PANES; i++) {
+      const paneEl = document.getElementById(`term-pane-${i}`);
+      if (paneEl) paneEl.classList.remove('terminal-pane-active');
+    }
+    if (this._activeTerminalSlot !== null) {
+      const activePaneEl = document.getElementById(
+        `term-pane-${this._activeTerminalSlot}`
+      );
+      if (activePaneEl && this.terminalPanes[this._activeTerminalSlot]) {
+        activePaneEl.classList.add('terminal-pane-active');
+      }
+    }
+    this.terminalPanes.forEach((tp, index) => {
+      if (!tp) return;
+      if (typeof tp.setFocused === 'function') {
+        tp.setFocused(index === this._activeTerminalSlot);
+      }
+      if (index !== this._activeTerminalSlot &&
+          typeof tp.blur === 'function') {
+        tp.blur();
+      }
+    });
+    const activeTp = Number.isInteger(this._activeTerminalSlot)
+      ? this.terminalPanes[this._activeTerminalSlot]
+      : null;
+    const activePaneHost = Number.isInteger(this._activeTerminalSlot)
+      ? document.getElementById(`term-pane-${this._activeTerminalSlot}`)
+      : null;
+    if (activeTp && !activePaneHost?.dataset?.viewType &&
+        typeof activeTp.focus === 'function') {
+      activeTp.focus();
+    }
 
     // Always reset grid layout for the new group's pane count.
     // Without this, switching to an empty tab group keeps the
@@ -19808,6 +20439,7 @@ class CWMApp {
     this.updateTerminalGridLayout();
 
     this.renderTerminalGroupTabs();
+    if (this.isMobile) this.updateTerminalTabs();
 
     // Clear notification dot on the now-active tab AFTER render, since
     // renderTerminalGroupTabs() replaces all tab button DOM elements.
@@ -20285,23 +20917,12 @@ class CWMApp {
     };
 
     // Dispose the terminal in the current tab (WebSocket disconnects, PTY stays alive)
+    this._discardVoiceRecognition(srcSlot, tp);
     tp.dispose();
     this.terminalPanes[srcSlot] = null;
 
-    // Reset the pane DOM to empty drop-target state
-    const paneEl = document.getElementById(`term-pane-${srcSlot}`);
-    if (paneEl) {
-      paneEl.classList.add('terminal-pane-empty');
-      paneEl.classList.remove('terminal-pane-active');
-      const header = paneEl.querySelector('.terminal-pane-title');
-      if (header) header.textContent = 'Drop a session here';
-      const closeBtn = paneEl.querySelector('.terminal-pane-close');
-      if (closeBtn) closeBtn.hidden = true;
-      const uploadBtn = paneEl.querySelector('.terminal-pane-upload');
-      if (uploadBtn) uploadBtn.hidden = true;
-      const termContainer = paneEl.querySelector('.terminal-container');
-      if (termContainer) termContainer.innerHTML = '';
-    }
+    // Reset every fixed-host resource before the slot is reused.
+    this._resetTerminalPaneHost(srcSlot);
 
     // Update grid layout for current tab
     this.updateTerminalGridLayout();
@@ -22854,11 +23475,22 @@ class CWMApp {
    * Upload an image file and send its path to a terminal session.
    * Shows a preview + optional message prompt before injecting.
    * @param {File} file - Image file from file input or drag-and-drop
-   * @param {number} slotIdx - Terminal pane slot index
+   * @param {number|Object} target - Slot index for immediate drops, or the
+   *   stable {terminalPane, groupId} captured before a native file picker.
    */
-  async handleImageUpload(file, slotIdx) {
-    const tp = this.terminalPanes[slotIdx];
-    if (!tp || !tp.sessionId) {
+  async handleImageUpload(file, target) {
+    const uploadTarget = typeof target === 'number'
+      ? {
+          terminalPane: this.terminalPanes[target],
+          groupId: this._activeGroupId,
+        }
+      : target;
+    const tp = uploadTarget && uploadTarget.terminalPane;
+    const ownerGroupId = uploadTarget && uploadTarget.groupId;
+    const ownerStillLive = () =>
+      this._activeGroupId === ownerGroupId &&
+      this.terminalPanes.includes(tp);
+    if (!tp || !tp.sessionId || !ownerStillLive()) {
       this.showToast('No active session in this pane', 'warning');
       return;
     }
@@ -22896,6 +23528,10 @@ class CWMApp {
       this.showToast('Upload failed: ' + err.message, 'error');
       return;
     }
+    if (!ownerStillLive()) {
+      this.showToast('Pane changed, image upload canceled', 'warning');
+      return;
+    }
 
     // Show prompt modal with image thumbnail preview
     const thumbUrl = URL.createObjectURL(file);
@@ -22919,7 +23555,8 @@ class CWMApp {
     if (!result) return; // User cancelled
 
     // Inject into PTY via WebSocket
-    if (!tp.ws || tp.ws.readyState !== WebSocket.OPEN) {
+    if (!ownerStillLive() ||
+        !tp.ws || tp.ws.readyState !== WebSocket.OPEN) {
       this.showToast('Terminal not connected', 'warning');
       return;
     }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1989,13 +1989,13 @@
        server-side /api/providers metadata onto these locals to build the
        runtime map window.CWMProviderSpecs. -->
   <script src="provider-specs.js"></script>
-  <script src="terminal.js?v=20260725-copymode3-focused5"></script>
+  <script src="terminal.js?v=20260725-copy-native5"></script>
   <script src="instance-colors.js"></script>
   <!-- Issue #10 Tier 1 Phase 4: MirrorPaneView (read-only session mirror).
        MUST load before app.js so window.MirrorPaneView exists when
        _renderMirrorInPane mounts a mirror pane. -->
-  <script src="mirror-view.js"></script>
-  <script src="app.js?v=20260725-copytruth-focused5"></script>
+  <script src="mirror-view.js?v=20260725-copy-native5"></script>
+  <script src="app.js?v=20260725-copy-native5"></script>
   <script src="schedules.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/src/web/public/mirror-view.js
+++ b/src/web/public/mirror-view.js
@@ -56,6 +56,8 @@ class MirrorPaneView {
    *   never a literal).
    * @param {string} opts.providerSessionId - Upstream session id to mirror.
    * @param {string} [opts.title] - Display title for the header.
+   * @param {{pinnedToBottom:boolean,scrollTop:number}|null} [opts.scrollState]
+   *   Saved reading position from a tab-group or layout transition.
    * @param {(method: string, path: string, body?: object) => Promise<object>} opts.api
    *   CWMApp.api bound to the app (carries auth).
    * @param {(str: string) => string} opts.escapeHtml - HTML escaper.
@@ -67,6 +69,7 @@ class MirrorPaneView {
     this.provider = String(o.provider || '');
     this.providerSessionId = String(o.providerSessionId || '');
     this.title = o.title || this.providerSessionId;
+    this._restoreScrollState = o.scrollState || null;
     this._api = o.api;
     this._esc = o.escapeHtml;
     this.deviceId = String(o.deviceId || '');
@@ -103,13 +106,15 @@ class MirrorPaneView {
    * Serializable descriptor used by the pane-layout persistence so a
    * restored layout can re-open this exact mirror.
    *
-   * @returns {{provider:string, providerSessionId:string, title:string}}
+   * @returns {{provider:string, providerSessionId:string, title:string,
+   *   scrollState:{pinnedToBottom:boolean,scrollTop:number}}}
    */
   descriptor() {
     return {
       provider: this.provider,
       providerSessionId: this.providerSessionId,
       title: this.title,
+      scrollState: this._captureScrollState(),
     };
   }
 
@@ -126,6 +131,9 @@ class MirrorPaneView {
    */
   async open() {
     if (this._disposed) return;
+    const scrollState = this._openedOnce
+      ? this._captureScrollState()
+      : this._restoreScrollState;
     this._renderSkeleton();
     let res;
     try {
@@ -146,7 +154,8 @@ class MirrorPaneView {
     this._setLive(!!res.live);
     this._elMessages.innerHTML = this._renderMessagesHtml(res.history || []);
     this._updateLoadEarlier();
-    this._scrollToBottom();
+    this._restoreScrollPosition(scrollState);
+    this._restoreScrollState = null;
   }
 
   /**
@@ -379,6 +388,28 @@ class MirrorPaneView {
     const el = this._elMessages;
     if (!el) return true;
     return el.scrollHeight - (el.scrollTop + el.clientHeight) <= MIRROR_VIEW_AUTOSCROLL_SLACK_PX;
+  }
+
+  /** Capture enough state to preserve whether the user is reading history. */
+  _captureScrollState() {
+    const el = this._elMessages;
+    if (!el) return { pinnedToBottom: true, scrollTop: 0 };
+    return {
+      pinnedToBottom: this._isPinnedToBottom(),
+      scrollTop: Number.isFinite(el.scrollTop) ? el.scrollTop : 0,
+    };
+  }
+
+  /** Restore a saved reading position, or follow the live tail by default. */
+  _restoreScrollPosition(state) {
+    if (!this._elMessages || !state || state.pinnedToBottom !== false) {
+      this._scrollToBottom();
+      return;
+    }
+    const requested = Number(state.scrollTop);
+    this._elMessages.scrollTop = Number.isFinite(requested)
+      ? Math.max(0, requested)
+      : 0;
   }
 
   /** Jump the message list to its bottom (newest content). */

--- a/src/web/public/terminal.js
+++ b/src/web/public/terminal.js
@@ -472,13 +472,16 @@ class TerminalPane {
    * on insecure origins, which is why the paste path can only degrade to a
    * "press Ctrl+V" hint while this helper has a real universal fallback.
    *
-   * Feature-detects the writeText FUNCTION, not just the clipboard object:
-   * some engines expose a navigator.clipboard object without writeText, and
-   * calling through a mere object check would reintroduce the throw.
+   * Gesture ordering matters: an embedded browser may expose writeText but
+   * reject it only after the trusted click has expired. Explicit copy actions
+   * therefore try the synchronous execCommand path FIRST, while user
+   * activation is unquestionably live, then use writeText when that path is
+   * unavailable (for example, an async action outside a click). The function
+   * check remains required because some engines expose a clipboard object
+   * without writeText.
    *
    * Contract: NEVER throws and the returned promise NEVER rejects, under any
-   * circumstance, so callers inside key and click handlers stay
-   * exception-safe.
+   * circumstance, so callers inside click handlers stay exception-safe.
    *
    * @param {string} text - Text to place on the clipboard ('' when nullish).
    * @returns {Promise<boolean>} Resolves true when the copy succeeded, false
@@ -487,14 +490,22 @@ class TerminalPane {
   static copyTextToClipboard(text) {
     const value = (text === null || text === undefined) ? '' : String(text);
     try {
+      // Preserve the trusted user gesture. If this helper was entered from a
+      // menu/button click, execCommand(copy) runs synchronously in that same
+      // stack and cannot lose activation while an async permission check is
+      // settling. When the helper is called outside a gesture it simply
+      // reports false and the modern Clipboard API remains available below.
+      try {
+        if (TerminalPane._copyViaExecCommand(value)) {
+          return Promise.resolve(true);
+        }
+      } catch (_) {}
+
       if (typeof navigator !== 'undefined' && navigator.clipboard &&
           typeof navigator.clipboard.writeText === 'function') {
-        // Secure context: async Clipboard API. Map BOTH outcomes so the
-        // promise can never reject. On rejection (Safari and some mobile
-        // browsers deny programmatic writes even on https) attempt the
-        // execCommand fallback before giving up; by the time the rejection
-        // lands the user gesture may have expired, in which case execCommand
-        // simply reports false, so trying is harmless.
+        // Modern async fallback. Map BOTH outcomes so the promise can never
+        // reject. A second execCommand attempt on rejection is harmless and
+        // can still help engines that retain activation for the microtask.
         return navigator.clipboard.writeText(value).then(
           () => true,
           () => {
@@ -502,42 +513,10 @@ class TerminalPane {
           }
         );
       }
-      // Insecure origin (or clipboard API absent): synchronous fallback.
-      return Promise.resolve(TerminalPane._copyViaExecCommand(value));
-    } catch (_) {
-      // Belt and braces: nothing above should throw, but the whole point of
-      // this helper is that callers NEVER see an exception. A throw escaping
-      // a key handler is exactly the bug that sent SIGINT to running CLIs.
       return Promise.resolve(false);
-    }
-  }
-
-  /**
-   * Return a stable identity for the terminal's current xterm selection range.
-   *
-   * Clipboard writes can settle asynchronously. Text alone is insufficient
-   * to decide whether it is still safe to clear the old selection because the
-   * user may select an identical string elsewhere while the write is pending.
-   * xterm exposes a public 1-based range; collapse it to a scalar key so the
-   * key handler can compare the exact start/end coordinates.
-   *
-   * @param {Object} term - xterm Terminal instance (or a test double).
-   * @returns {string|null} Range key, empty string for no range, or null when
-   *   the installed xterm API does not expose a readable range.
-   */
-  static _selectionPositionKey(term) {
-    if (!term || typeof term.getSelectionPosition !== 'function') return null;
-    try {
-      const range = term.getSelectionPosition();
-      if (!range) return '';
-      return [
-        range.start && range.start.x,
-        range.start && range.start.y,
-        range.end && range.end.x,
-        range.end && range.end.y,
-      ].join(':');
     } catch (_) {
-      return null;
+      // Belt and braces: callers never see a gesture-handler exception.
+      return Promise.resolve(false);
     }
   }
 
@@ -704,6 +683,9 @@ class TerminalPane {
     this._selMouseHandler = null;
     this._selInterceptorContainer = null;
     this._selectDragging = false;
+    this._hostMobileTypeMode = undefined;
+    this._mobileSelectionResetTimer = null;
+    this._copyHintShown = false;
     // Issue #41: true while a mobile touch gesture (or its momentum tail) is
     // driving term.scrollLines() directly. xterm's smoothScrollDuration is
     // zeroed for that window so the engine's per-frame interpolation is not
@@ -715,6 +697,14 @@ class TerminalPane {
     // dimensions really changed (see _sendResizeIfChanged).
     this._lastSentCols = null;
     this._lastSentRows = null;
+    // Mount has two deferred animation frames plus a delayed refit. Track a
+    // generation and every handle so dispose-before-frame cannot resurrect a
+    // closed pane or connect a stale WebSocket.
+    this._disposed = false;
+    this._mountGeneration = 0;
+    this._mountRafOuter = null;
+    this._mountRafInner = null;
+    this._mountRefitTimer = null;
     // Plan 19-02 (PTY-04, PTY-05): per-pane provider context. Both fields are
     // populated in mount() after the pane DOM exists. _providerId drives idle
     // detection and Shift+Enter dispatch; defaults to the back-compat provider
@@ -726,6 +716,24 @@ class TerminalPane {
 
   _log(msg) {
     console.log('[Terminal]', msg);
+  }
+
+  /**
+   * Resolve the fixed DOM container only while it still renders this exact
+   * TerminalPane. Cached groups keep their WebSocket alive while the same
+   * container id hosts another session, so id lookup alone is never proof of
+   * ownership.
+   */
+  _getOwnedContainer() {
+    if (typeof document === 'undefined' ||
+        !this.term || !this.term.element) return null;
+    const container = document.getElementById(this.containerId);
+    if (!container ||
+        this.term.element.parentElement !== container ||
+        this.term.element.__cwmTerminalPane !== this) {
+      return null;
+    }
+    return container;
   }
 
   /** Write a colored status message through the batching pipeline to avoid freezing */
@@ -742,6 +750,8 @@ class TerminalPane {
   }
 
   mount() {
+    if (this._disposed) return;
+    const mountGeneration = ++this._mountGeneration;
     const container = document.getElementById(this.containerId);
     if (!container) {
       console.error('[Terminal] Container not found:', this.containerId);
@@ -784,6 +794,11 @@ class TerminalPane {
       }
 
       this.term.open(container);
+      // Stamp the live xterm root with its owning TerminalPane. Fixed grid
+      // slots can be reused while cached panes and deferred mounts overlap;
+      // event routing must follow the terminal that actually rendered the
+      // target, not merely whichever object is currently in a slot array.
+      if (this.term.element) this.term.element.__cwmTerminalPane = this;
       this._log('xterm opened in ' + this.containerId + ' for session ' + this.sessionId);
 
       // Plan 19-02 (PTY-04, PTY-05): read this pane's provider tag once at
@@ -819,8 +834,12 @@ class TerminalPane {
       // the display and forces users to type "reset".
       //
       // Double-rAF ensures the grid layout is fully calculated before fit.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
+      this._mountRafOuter = requestAnimationFrame(() => {
+        this._mountRafOuter = null;
+        if (this._disposed || this._mountGeneration !== mountGeneration) return;
+        this._mountRafInner = requestAnimationFrame(() => {
+          this._mountRafInner = null;
+          if (this._disposed || this._mountGeneration !== mountGeneration) return;
           try {
             this.fitAddon.fit();
             this._log('Fitted: ' + this.term.cols + 'x' + this.term.rows);
@@ -836,8 +855,11 @@ class TerminalPane {
           // is still settling (e.g., CSS transitions, slow layout).
           // Deduplicated: only notifies the server when dims really changed,
           // so the common already-settled case sends nothing.
-          setTimeout(() => {
-            if (this.fitAddon) {
+          this._mountRefitTimer = setTimeout(() => {
+            this._mountRefitTimer = null;
+            if (!this._disposed &&
+                this._mountGeneration === mountGeneration &&
+                this.fitAddon) {
               try {
                 this.fitAddon.fit();
                 this._sendResizeIfChanged(false);
@@ -856,70 +878,21 @@ class TerminalPane {
         // to xterm's control-character path merely because letter case changed.
         const shortcutKey = typeof e.key === 'string' ? e.key.toLowerCase() : '';
 
-        // Ctrl+C / Cmd+C: copy selected text to clipboard (if selection exists)
-        // Without selection, fall through so xterm sends \x03 (SIGINT) normally.
+        // Ctrl+C / Cmd+C with an xterm selection belongs to the browser's
+        // trusted native copy path. Returning false keeps xterm from turning
+        // the shortcut into ETX/SIGINT, while deliberately NOT calling
+        // preventDefault lets Chromium dispatch its trusted `copy` event.
+        // xterm owns that event on the terminal element and synchronously
+        // writes its selection through ClipboardEvent.clipboardData.
         //
-        // WHY the try/catch bracket and the helper (user report, 2026-07-24):
-        // this branch used to call the async Clipboard API directly with a
-        // chained .catch(). On insecure origins (plain http to a LAN IP or
-        // hostname, the documented remote-access mode) navigator.clipboard is
-        // undefined, so the PROPERTY ACCESS threw a synchronous TypeError
-        // that .catch() could not see (.catch only intercepts promise
-        // rejections, not a throw during property lookup). The exception
-        // escaped this handler BEFORE clearSelection() and `return false`
-        // ran, xterm treated the key as unhandled, and the "copy" keystroke
-        // sent \x03 (SIGINT) that interrupted the user's running CLI
-        // session. Same secure-context trap as paste issue #64, which was
-        // fixed on the Ctrl+V branch below but never applied here.
-        //
-        // TerminalPane.copyTextToClipboard never throws by contract and uses
-        // execCommand as a best-effort fallback on every origin. Its boolean
-        // result still matters: clear the selection only after a confirmed
-        // copy. If every browser path fails, keep the selection recoverable
-        // and tell the app shell to show an honest error.
-        //
-        // The bracket below makes the SIGINT fall-through STRUCTURALLY
-        // impossible even if a future edit regresses the helper's no-throw
-        // guarantee: once a selection exists this branch always reaches
-        // `return false` and consumes the key. Do not lift the copy call out
-        // of the try.
-        if (mod && shortcutKey === 'c' && this.term.hasSelection()) {
-          try {
-            // Returning false tells xterm not to forward Ctrl+C to the PTY,
-            // but it does not cancel Chromium's native copy/default action.
-            // Cancel that second clipboard path before starting our truthful,
-            // success-aware helper. This is intentionally selection-only:
-            // plain Ctrl+C must still reach the terminal as SIGINT.
-            if (typeof e.preventDefault === 'function') e.preventDefault();
-            const selectedText = this.term.getSelection();
-            const selectedPositionKey = TerminalPane._selectionPositionKey(this.term);
-            Promise.resolve(TerminalPane.copyTextToClipboard(selectedText)).then(
-              (copied) => {
-                if (copied) {
-                  try {
-                    // Do not erase a newer selection made while an async
-                    // Clipboard API write was settling. Compare both its text
-                    // and exact xterm range: identical text may occur twice.
-                    const currentPositionKey = TerminalPane._selectionPositionKey(this.term);
-                    const samePosition = selectedPositionKey === null ||
-                      currentPositionKey === selectedPositionKey;
-                    if (this.term && this.term.getSelection() === selectedText && samePosition) {
-                      this.term.clearSelection();
-                    }
-                  } catch (_) {
-                    // The copy itself succeeded; a stale/disposed terminal
-                    // should not turn that into a misleading failure toast.
-                  }
-                } else {
-                  this._emitCopyUnavailable('failed');
-                }
-              },
-              () => this._emitCopyUnavailable('failed')
-            );
-          } catch (_) {
-            this._emitCopyUnavailable('failed');
-          }
-          return false;
+        // This is more reliable than an async navigator.clipboard.writeText
+        // call: embedded browsers can expose the API while denying the
+        // permission, and preventDefault previously disabled the native path
+        // that would still have worked. With no selection this branch is
+        // skipped, preserving ordinary terminal Ctrl+C/SIGINT.
+        if (mod && shortcutKey === 'c') {
+          const copySelection = this.getCopySelection();
+          if (copySelection.hasSelection) return false;
         }
 
         // Ctrl+V / Cmd+V always stays on the browser's trusted native paste
@@ -1130,7 +1103,7 @@ class TerminalPane {
     this._log('Opening WebSocket: ' + wsUrl.substring(0, 80) + '...');
 
     // Add loading animation to the pane
-    const container = document.getElementById(this.containerId);
+    const container = this._getOwnedContainer();
     const paneEl = container ? container.closest('.terminal-pane') : null;
     if (paneEl) paneEl.classList.add('terminal-pane-loading');
 
@@ -1145,7 +1118,7 @@ class TerminalPane {
 
     this.ws.onopen = () => {
       // Remove loading animation
-      const paneEl = document.getElementById(this.containerId)?.closest('.terminal-pane');
+      const paneEl = this._getOwnedContainer()?.closest('.terminal-pane');
       if (paneEl) paneEl.classList.remove('terminal-pane-loading');
 
       this.connected = true;
@@ -1222,7 +1195,7 @@ class TerminalPane {
 
     this.ws.onclose = (event) => {
       // Remove loading animation
-      const paneEl = document.getElementById(this.containerId)?.closest('.terminal-pane');
+      const paneEl = this._getOwnedContainer()?.closest('.terminal-pane');
       if (paneEl) paneEl.classList.remove('terminal-pane-loading');
 
       this.connected = false;
@@ -1259,14 +1232,13 @@ class TerminalPane {
     if (!this.term) return;
     // On mobile in scroll mode, don't focus textarea (prevents keyboard popup)
     if (this._isMobile() && !this._mobileTypeMode) return;
+    const container = this._getOwnedContainer();
+    if (!container || container.hidden) return;
     this.term.focus();
     // Also explicitly focus the hidden textarea - xterm.js's focus()
     // sometimes doesn't propagate in multi-instance setups
-    const container = document.getElementById(this.containerId);
-    if (container) {
-      const textarea = container.querySelector('.xterm-helper-textarea');
-      if (textarea) textarea.focus({ preventScroll: true });
-    }
+    const textarea = container.querySelector('.xterm-helper-textarea');
+    if (textarea) textarea.focus({ preventScroll: true });
   }
 
   blur() {
@@ -1327,26 +1299,152 @@ class TerminalPane {
   }
 
   /**
-   * Surface a failed Ctrl+C/Cmd+C copy through the app shell.
+   * Read the selection the user can currently copy from this pane.
    *
-   * The key remains consumed so it can never become SIGINT, while the xterm
-   * selection remains intact so the user can retry. Notification dispatch is
-   * best-effort and must never escape back into the terminal key handler.
-   * @param {string} reason - Stable failure reason for the app shell.
+   * xterm normally owns selection state. A native DOM selection is also
+   * accepted when both endpoints live inside this pane; that covers touch/
+   * coarse-pointer and renderer fallback states where the browser visibly
+   * highlights terminal text but xterm's model reports no selection.
+   *
+   * @returns {{hasSelection:boolean,text:string,source:'xterm'|'dom'|null}}
    */
-  _emitCopyUnavailable(reason) {
+  getCopySelection() {
     try {
-      if (typeof document === 'undefined') return;
-      const container = document.getElementById(this.containerId);
-      const target = container || document;
-      if (!target || typeof target.dispatchEvent !== 'function') return;
-      target.dispatchEvent(new CustomEvent('cwm:copy-unavailable', {
-        bubbles: true,
-        detail: { reason, containerId: this.containerId, sessionId: this.sessionId },
-      }));
+      if (this.term && typeof this.term.hasSelection === 'function' &&
+          this.term.hasSelection()) {
+        return {
+          hasSelection: true,
+          text: typeof this.term.getSelection === 'function'
+            ? String(this.term.getSelection())
+            : '',
+          source: 'xterm',
+        };
+      }
+    } catch (_) {}
+
+    try {
+      if (typeof document === 'undefined' ||
+          typeof document.getSelection !== 'function') {
+        return { hasSelection: false, text: '', source: null };
+      }
+      const selection = document.getSelection();
+      const pane = this.paneEl ||
+        this._getOwnedContainer()?.closest('.terminal-pane');
+      if (!selection || selection.isCollapsed || !pane ||
+          !selection.anchorNode || !selection.focusNode ||
+          !pane.contains(selection.anchorNode) ||
+          !pane.contains(selection.focusNode)) {
+        return { hasSelection: false, text: '', source: null };
+      }
+      return {
+        hasSelection: true,
+        text: String(selection.toString()),
+        source: 'dom',
+      };
     } catch (_) {
-      // Never let a notification failure escape into the Ctrl+C key path.
+      return { hasSelection: false, text: '', source: null };
     }
+  }
+
+  /**
+   * Detach every slot-owned listener/control while keeping the live xterm,
+   * WebSocket, buffer, and selection intact.
+   *
+   * Terminal tab groups reuse fixed slot containers. Cached panes therefore
+   * must release their host bindings before another group mounts in the same
+   * DOM, otherwise Select buttons and capture listeners control a hidden
+   * TerminalPane. Pane drag/reorder uses the same lifecycle before rebinding
+   * a live terminal to its destination slot.
+   *
+   * @returns {boolean} true when host bindings were detached.
+   */
+  detachHostBindings() {
+    if (this._hostMobileTypeMode === undefined) {
+      this._hostMobileTypeMode = !!this._mobileTypeMode;
+    }
+
+    if (this._touchScrollCleanup) {
+      try { this._touchScrollCleanup(); } catch (_) {}
+      this._touchScrollCleanup = null;
+    }
+    this._xtermTextarea = null;
+    this._xtermScreen = null;
+    this._xtermViewport = null;
+    this._mobileSelecting = false;
+    if (this._mobileSelectionResetTimer) {
+      clearTimeout(this._mobileSelectionResetTimer);
+      this._mobileSelectionResetTimer = null;
+    }
+
+    if (this._resizeObserver) this._resizeObserver.disconnect();
+
+    if (this._copyHintTimer) {
+      clearTimeout(this._copyHintTimer);
+      this._copyHintTimer = null;
+    }
+    if (this._selInterceptorContainer && this._selMouseHandler) {
+      try {
+        this._selInterceptorContainer.removeEventListener('mousedown', this._selMouseHandler, true);
+        this._selInterceptorContainer.removeEventListener('mousemove', this._selMouseHandler, true);
+        this._selInterceptorContainer.removeEventListener('mouseup', this._selMouseHandler, true);
+      } catch (_) {}
+    }
+    this._selMouseHandler = null;
+    this._selInterceptorContainer = null;
+
+    if (this.paneEl) this.paneEl.classList.remove('select-mode-on');
+    if (this._selectModeBtn) {
+      try { this._selectModeBtn.remove(); } catch (_) {}
+      this._selectModeBtn = null;
+    }
+    if (this._selStrip) {
+      try { this._selStrip.remove(); } catch (_) {}
+      this._selStrip = null;
+    }
+    if (this._copyHint) {
+      try { this._copyHint.remove(); } catch (_) {}
+      this._copyHint = null;
+    }
+    this.paneEl = null;
+    return true;
+  }
+
+  /**
+   * Rebind a live TerminalPane to the fixed DOM host for its current slot.
+   *
+   * @param {string} containerId - Destination terminal-container id.
+   * @returns {boolean} true when the destination exists and was rebound.
+   */
+  rebindHost(containerId) {
+    const container = typeof document !== 'undefined'
+      ? document.getElementById(containerId)
+      : null;
+    if (!container) return false;
+
+    this.detachHostBindings();
+    const restoreMobileTypeMode = !!this._hostMobileTypeMode;
+    this._hostMobileTypeMode = undefined;
+    this.containerId = containerId;
+    this.paneEl = container.closest('.terminal-pane');
+
+    if (this.term && this.term.element &&
+        this.term.element.parentElement !== container) {
+      container.appendChild(this.term.element);
+    }
+    if (this.term && this.term.element) {
+      this.term.element.__cwmTerminalPane = this;
+    }
+
+    if (this.term) {
+      this._installSelectModeInterceptor();
+      this._injectCopyControls();
+      if (this._resizeObserver) this._resizeObserver.observe(container);
+      if (this._isMobile()) {
+        this.initMobileInputMode();
+        if (restoreMobileTypeMode) this.setMobileTypeMode();
+      }
+    }
+    return true;
   }
 
   /**
@@ -1364,7 +1462,7 @@ class TerminalPane {
   _emitPasteUnavailable(reason) {
     try {
       if (typeof document === 'undefined') return;
-      const container = document.getElementById(this.containerId);
+      const container = this._getOwnedContainer();
       const target = container || document;
       if (!target || typeof target.dispatchEvent !== 'function') return;
       target.dispatchEvent(new CustomEvent('cwm:paste-unavailable', {
@@ -1401,7 +1499,7 @@ class TerminalPane {
     // pass (the container is visible, just hosting someone else) and a fit
     // against the detached element would send bogus dims to this pane's PTY.
     if (!this.term.element || !this.term.element.isConnected) return;
-    const container = document.getElementById(this.containerId);
+    const container = this._getOwnedContainer();
     if (!container) return;
     const rect = container.getBoundingClientRect();
     if (rect.width === 0 || rect.height === 0) return;
@@ -1524,7 +1622,7 @@ class TerminalPane {
     this._mobileTypeMode = false;
     this._mobileSelecting = false;
 
-    const container = document.getElementById(this.containerId);
+    const container = this._getOwnedContainer();
     if (!container) return;
     const textarea = container.querySelector('.xterm-helper-textarea');
     if (!textarea) return;
@@ -1702,7 +1800,13 @@ class TerminalPane {
         // Long-press converted this gesture into selection; no momentum will
         // run, so this is also a gesture-end path (issue #41).
         restoreSmoothScroll();
-        setTimeout(() => this._disableMobileSelection(), 300);
+        if (this._mobileSelectionResetTimer) {
+          clearTimeout(this._mobileSelectionResetTimer);
+        }
+        this._mobileSelectionResetTimer = setTimeout(() => {
+          this._mobileSelectionResetTimer = null;
+          this._disableMobileSelection();
+        }, 300);
         return;
       }
 
@@ -1745,6 +1849,10 @@ class TerminalPane {
    * but keeps textarea pointer-events disabled to prevent keyboard popup.
    */
   _enableMobileSelection() {
+    if (this._mobileSelectionResetTimer) {
+      clearTimeout(this._mobileSelectionResetTimer);
+      this._mobileSelectionResetTimer = null;
+    }
     this._mobileSelecting = true;
     if (this._xtermScreen) this._xtermScreen.style.pointerEvents = 'auto';
     // Haptic feedback if available (subtle vibration signals selection mode)
@@ -1942,9 +2050,9 @@ class TerminalPane {
     if (newActivity && (!this._currentActivity || this._currentActivity.type !== newActivity.type || this._currentActivity.detail !== newActivity.detail)) {
       this._currentActivity = newActivity;
       // Dispatch custom event for the app layer
-      const container = document.getElementById(this.containerId);
-      if (container) {
-        container.dispatchEvent(new CustomEvent('terminal-activity', {
+      const eventTarget = this._getOwnedContainer() || document;
+      if (eventTarget && typeof eventTarget.dispatchEvent === 'function') {
+        eventTarget.dispatchEvent(new CustomEvent('terminal-activity', {
           bubbles: true,
           detail: { sessionId: this.sessionId, activity: newActivity }
         }));
@@ -1976,8 +2084,10 @@ class TerminalPane {
       this._needsInputTimer = setTimeout(() => {
         if (this._needsInput) {
           this._needsInput = false;
-          const el = document.getElementById(this.containerId);
-          if (el) el.dispatchEvent(new CustomEvent('terminal-needs-input', { bubbles: true, detail: { sessionId: this.sessionId, needsInput: false } }));
+          const eventTarget = this._getOwnedContainer() || document;
+          if (eventTarget && typeof eventTarget.dispatchEvent === 'function') {
+            eventTarget.dispatchEvent(new CustomEvent('terminal-needs-input', { bubbles: true, detail: { sessionId: this.sessionId, needsInput: false } }));
+          }
         }
       }, 5000);
     }
@@ -2037,9 +2147,9 @@ class TerminalPane {
       // Update activity to idle when prompt is detected
       this._currentActivity = { type: 'idle', detail: 'Waiting for input' };
       this._activityBuffer = '';
-      const idleContainer = document.getElementById(this.containerId);
-      if (idleContainer) {
-        idleContainer.dispatchEvent(new CustomEvent('terminal-activity', {
+      const idleTarget = this._getOwnedContainer() || document;
+      if (idleTarget && typeof idleTarget.dispatchEvent === 'function') {
+        idleTarget.dispatchEvent(new CustomEvent('terminal-activity', {
           bubbles: true,
           detail: { sessionId: this.sessionId, activity: this._currentActivity }
         }));
@@ -2060,9 +2170,9 @@ class TerminalPane {
       this._lastIdleFiredAt = Date.now();
 
       // Dispatch custom event for the app to handle
-      const container = document.getElementById(this.containerId);
-      if (container) {
-        container.dispatchEvent(new CustomEvent('terminal-idle', {
+      const idleEventTarget = this._getOwnedContainer() || document;
+      if (idleEventTarget && typeof idleEventTarget.dispatchEvent === 'function') {
+        idleEventTarget.dispatchEvent(new CustomEvent('terminal-idle', {
           bubbles: true,
           detail: { sessionId: this.sessionId, sessionName: this.sessionName }
         }));
@@ -2132,9 +2242,9 @@ class TerminalPane {
       // Dangerous prompt: always require human input regardless of auto-trust setting
       if (!this._needsInput) {
         this._needsInput = true;
-        const el = document.getElementById(this.containerId);
-        if (el) {
-          el.dispatchEvent(new CustomEvent('terminal-needs-input', {
+        const eventTarget = this._getOwnedContainer() || document;
+        if (eventTarget && typeof eventTarget.dispatchEvent === 'function') {
+          eventTarget.dispatchEvent(new CustomEvent('terminal-needs-input', {
             bubbles: true,
             detail: { sessionId: this.sessionId, needsInput: true }
           }));
@@ -2157,9 +2267,9 @@ class TerminalPane {
       // Auto-trust not enabled: flag as needing human input
       if (!this._needsInput) {
         this._needsInput = true;
-        const el = document.getElementById(this.containerId);
-        if (el) {
-          el.dispatchEvent(new CustomEvent('terminal-needs-input', {
+        const eventTarget = this._getOwnedContainer() || document;
+        if (eventTarget && typeof eventTarget.dispatchEvent === 'function') {
+          eventTarget.dispatchEvent(new CustomEvent('terminal-needs-input', {
             bubbles: true,
             detail: { sessionId: this.sessionId, needsInput: true }
           }));
@@ -2267,7 +2377,7 @@ class TerminalPane {
    * there is no selection and the toggle is off.
    */
   _installSelectModeInterceptor() {
-    const container = document.getElementById(this.containerId);
+    const container = this._getOwnedContainer();
     if (!container) return;
     // Idempotent: a remount into the same slot must not stack interceptors.
     if (this._selInterceptorContainer && this._selMouseHandler) {
@@ -2279,13 +2389,19 @@ class TerminalPane {
     }
     this._selectDragging = false;
     const handler = (e) => {
-      // A right-button press over a genuine xterm selection belongs to the
-      // Workbook context menu, not the mouse-reporting TUI. Block xterm's
-      // same-event listener before the TUI can redraw or mutate the selected
-      // buffer, but do not preventDefault: the later contextmenu event must
-      // still open app.js's truthful Copy action.
-      if (e.type === 'mousedown' && e.button === 2 &&
-          this.term && this.term.hasSelection()) {
+      // Once text is selected, mouse-reporting TUIs must not see the hover
+      // move that precedes a physical right-click, nor either right-button
+      // edge. Full mouse mode reports even zero-button movement; Claude Code
+      // can redraw on that hover and clear xterm's selection before the later
+      // contextmenu event. Keep the selected buffer frozen through the whole
+      // gesture, but do not preventDefault so contextmenu still opens.
+      const selectedForCopy = this.getCopySelection().hasSelection;
+      const selectedHover =
+        e.type === 'mousemove' && !this._selectDragging &&
+        (e.buttons === 0 || e.buttons === undefined);
+      const selectedRightEdge =
+        (e.type === 'mousedown' || e.type === 'mouseup') && e.button === 2;
+      if (selectedForCopy && (selectedHover || selectedRightEdge)) {
         e.stopImmediatePropagation();
         return;
       }
@@ -2466,7 +2582,7 @@ class TerminalPane {
     try {
       if (localStorage.getItem('cwm_copyhint_v1')) return;
     } catch (_) { return; }
-    if (!this.paneEl || this._copyHint) return;
+    if (!this.paneEl || this._copyHint || this._copyHintShown) return;
     const h = document.createElement('div');
     h.className = 'terminal-copy-hint';
     h.style.cssText = 'position:absolute;top:36px;right:8px;z-index:30;max-width:248px;'
@@ -2485,6 +2601,11 @@ class TerminalPane {
     const x = h.querySelector('.terminal-copy-hint-x');
     if (x) x.addEventListener('click', (e) => { e.stopPropagation(); this._dismissCopyHint(); });
     this._copyHint = h;
+    this._copyHintShown = true;
+    // "One-time" means once shown, not once its 14-second timer eventually
+    // completes. Persist immediately so a swap, group-cache rebind, reload, or
+    // crash cannot resurrect the same onboarding card.
+    try { localStorage.setItem('cwm_copyhint_v1', '1'); } catch (_) {}
     this._copyHintTimer = setTimeout(() => this._dismissCopyHint(), 14000);
   }
 
@@ -2501,6 +2622,14 @@ class TerminalPane {
   }
 
   dispose() {
+    this._disposed = true;
+    this._mountGeneration++;
+    if (this._mountRafOuter) cancelAnimationFrame(this._mountRafOuter);
+    if (this._mountRafInner) cancelAnimationFrame(this._mountRafInner);
+    clearTimeout(this._mountRefitTimer);
+    this._mountRafOuter = null;
+    this._mountRafInner = null;
+    this._mountRefitTimer = null;
     clearTimeout(this.reconnectTimer);
     clearTimeout(this._fitTimer);
     clearTimeout(this._idleCheckTimer);
@@ -2513,24 +2642,15 @@ class TerminalPane {
     if (this._writeRaf) cancelAnimationFrame(this._writeRaf);
     this._writeBuf = '';
     this._activitySample = '';
-    if (this._touchScrollCleanup) this._touchScrollCleanup();
-    // Copy-mode teardown: remove the capture-phase mouse interceptor and any
-    // injected controls/hints so a remount into the same slot starts clean.
-    if (this._copyHintTimer) { clearTimeout(this._copyHintTimer); this._copyHintTimer = null; }
-    if (this._selInterceptorContainer && this._selMouseHandler) {
-      try {
-        this._selInterceptorContainer.removeEventListener('mousedown', this._selMouseHandler, { capture: true });
-        this._selInterceptorContainer.removeEventListener('mousemove', this._selMouseHandler, { capture: true });
-        this._selInterceptorContainer.removeEventListener('mouseup', this._selMouseHandler, { capture: true });
-      } catch (_) {}
-    }
-    this._selMouseHandler = null;
-    this._selInterceptorContainer = null;
-    if (this._selectModeBtn) { try { this._selectModeBtn.remove(); } catch (_) {} this._selectModeBtn = null; }
-    if (this._selStrip) { try { this._selStrip.remove(); } catch (_) {} this._selStrip = null; }
-    if (this._copyHint) { try { this._copyHint.remove(); } catch (_) {} this._copyHint = null; }
-    if (this._resizeObserver) this._resizeObserver.disconnect();
+    // Release every fixed-slot listener/control before disposing the live
+    // terminal. This is the same ownership boundary used by pane moves and
+    // tab-group caching, so teardown cannot drift from rebind behavior.
+    this.detachHostBindings();
     if (this.ws) { this.ws.onmessage = null; this.ws.onclose = null; this.ws.close(); }
+    if (this.term && this.term.element &&
+        this.term.element.__cwmTerminalPane === this) {
+      try { delete this.term.element.__cwmTerminalPane; } catch (_) {}
+    }
     if (this.term) this.term.dispose();
     this.term = null;
     this.ws = null;

--- a/test/browser/terminal-interaction-server.js
+++ b/test/browser/terminal-interaction-server.js
@@ -40,6 +40,7 @@ const ALLOWED_ASSETS = new Map([
 const state = {
   inputFrames: 0,
   mouseEvents: 0,
+  hoverMoves: 0,
   leftPresses: 0,
   rightPresses: 0,
   sigintCount: 0,
@@ -56,6 +57,7 @@ const state = {
 function resetState() {
   state.inputFrames = 0;
   state.mouseEvents = 0;
+  state.hoverMoves = 0;
   state.leftPresses = 0;
   state.rightPresses = 0;
   state.sigintCount = 0;
@@ -72,6 +74,7 @@ function snapshotState() {
   return {
     inputFrames: state.inputFrames,
     mouseEvents: state.mouseEvents,
+    hoverMoves: state.hoverMoves,
     leftPresses: state.leftPresses,
     rightPresses: state.rightPresses,
     sigintCount: state.sigintCount,
@@ -101,7 +104,7 @@ function enterAltMode() {
   state.mode = 'alt';
   broadcast(
     '\x1b[?1049h' +
-    '\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?2004h' +
+    '\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h\x1b[?2004h' +
     '\x1b[2J\x1b[H' +
     'MYRLIN MOUSE-CAPTURING TUI FIXTURE\r\n' +
     'COPY_TARGET_ALPHA_BETA_GAMMA\r\n' +
@@ -146,6 +149,9 @@ function observeInput(data) {
   for (const match of data.matchAll(mousePattern)) {
     state.mouseEvents++;
     const code = Number(match[1]);
+    if (match[4] === 'M' && (code & 32) !== 0 && (code & 3) === 3) {
+      state.hoverMoves++;
+    }
     if (match[4] === 'M' && (code & 3) === 0) state.leftPresses++;
     if (match[4] === 'M' && (code & 3) === 2) state.rightPresses++;
   }

--- a/test/browser/terminal-interaction.html
+++ b/test/browser/terminal-interaction.html
@@ -191,7 +191,9 @@
     async function resetFixtureState() {
       await fetch('/reset', { method: 'POST' });
       window.__copyAttempts.length = 0;
+      window.__nativeCopyEvents.length = 0;
       window.__toast = null;
+      window.__focusCalls = 0;
       await refreshFixtureState();
     }
 
@@ -272,8 +274,25 @@
     }
 
     window.__copyAttempts = [];
+    window.__nativeCopyEvents = [];
     window.__toast = null;
     localStorage.setItem('cwm_token', 'fixture-token');
+
+    // Bubble after xterm's target listener so the record contains the exact
+    // text xterm synchronously placed in ClipboardEvent.clipboardData.
+    document.addEventListener('copy', (event) => {
+      let text = '';
+      try {
+        text = event.clipboardData
+          ? event.clipboardData.getData('text/plain')
+          : '';
+      } catch (_) {}
+      window.__nativeCopyEvents.push({
+        trusted: event.isTrusted,
+        text,
+        defaultPrevented: event.defaultPrevented,
+      });
+    });
 
     document.addEventListener('DOMContentLoaded', async () => {
       const pane = new TerminalPane('fixture-terminal', 'fixture_session', 'Fixture TUI', {
@@ -295,11 +314,23 @@
       const CwmAppClass = await loadCwmAppClass();
       const menuApp = Object.create(CwmAppClass.prototype);
       menuApp.terminalPanes = [pane];
+      menuApp._activeTerminalSlot = 0;
       menuApp.state = {};
       menuApp._tabGroups = [];
       menuApp._activeGroupId = null;
       menuApp._buildSessionContextItems = () => null;
       menuApp.getSessionConflicts = () => [];
+      // Model the production pane-focus path adversarially: a refocus may
+      // clear xterm selection before the descendant right-button guard runs.
+      // The production _focusTerminalPaneFromPointer helper must skip this
+      // callback for a selected-text right press.
+      window.__focusCalls = 0;
+      menuApp.setActiveTerminalPane = (slot) => {
+        window.__focusCalls += 1;
+        menuApp._activeTerminalSlot = slot;
+        pane.term.clearSelection();
+        pane.focus();
+      };
       menuApp.showToast = (message, level) => {
         window.__toast = { message, level };
         const toast = document.getElementById('toast');
@@ -309,20 +340,25 @@
       menuApp._renderContextItems = renderFixtureContextMenu;
       window.__fixtureApp = menuApp;
 
-      // The fixture intentionally does not boot CWMApp._bindEvents. Mirror its
-      // production copy-failure listener so a real TerminalPane Ctrl+C event
-      // exercises the same visible outcome.
-      document.addEventListener('cwm:copy-unavailable', () => {
-        menuApp.showToast('Copy was blocked by the browser. Selection kept.', 'error');
-      });
-
       const paneElement = document.getElementById('term-pane-0');
-      paneElement.addEventListener('mousedown', () => pane.focus(), true);
+      paneElement.addEventListener('mousedown', (event) => {
+        menuApp._focusTerminalPaneFromPointer(0, event);
+      }, true);
       paneElement.addEventListener('contextmenu', (event) => {
+        const terminalPane = menuApp._terminalPaneFromPointerEvent(0, event);
+        const copySelection = terminalPane
+          ? terminalPane.getCopySelection()
+          : { hasSelection: false, text: '', source: null };
         event.preventDefault();
         event.stopPropagation();
-        menuApp.showTerminalContextMenu(0, event.clientX, event.clientY);
-      });
+        menuApp.showTerminalContextMenu(
+          0,
+          event.clientX,
+          event.clientY,
+          copySelection,
+          terminalPane
+        );
+      }, true);
 
       document.getElementById('mode-alt').addEventListener('click', () => setFixtureMode('alt'));
       document.getElementById('mode-normal').addEventListener('click', () => setFixtureMode('normal'));

--- a/test/browser/terminal-interaction.test.js
+++ b/test/browser/terminal-interaction.test.js
@@ -212,7 +212,7 @@ async function waitForFixture(page) {
     window.fixture.pane &&
     window.fixture.pane.connected === true &&
     window.fixture.pane.term &&
-    window.fixture.pane.term.modes.mouseTrackingMode === 'drag'
+    window.fixture.pane.term.modes.mouseTrackingMode === 'any'
   ), null, { timeout: 15000 });
 }
 
@@ -264,8 +264,11 @@ async function selectionGeometry(page) {
  */
 async function dragCopyTarget(page, withShift) {
   const geometry = await selectionGeometry(page);
-  if (withShift) await page.keyboard.down('Shift');
+  // Positioning the pointer is a distinct zero-button 1003 hover. Reset after
+  // that setup move so assertions below measure only the drag gesture itself.
   await page.mouse.move(geometry.x1, geometry.y);
+  await resetState(page);
+  if (withShift) await page.keyboard.down('Shift');
   await page.mouse.down({ button: 'left' });
   await page.mouse.move(geometry.x2, geometry.y, { steps: 10 });
   await page.mouse.up({ button: 'left' });
@@ -355,6 +358,18 @@ async function run() {
     assert.strictEqual(selection.hasSelection, false, 'plain drag must not select while Select mode is off');
     assert.ok(state.mouseEvents > 0, 'plain drag must reach the mouse-reporting TUI');
 
+    // DECSET 1003 reports movement even when no mouse button is down. Prove
+    // the fixture really exercises that mode before testing selected-hover
+    // suppression later.
+    await resetState(page);
+    const hoverGeometry = await selectionGeometry(page);
+    await page.mouse.move(hoverGeometry.x1, hoverGeometry.y + 28);
+    await page.mouse.move(hoverGeometry.x2, hoverGeometry.y + 28, { steps: 8 });
+    await page.waitForFunction(() => window.__fixtureState &&
+      window.__fixtureState.hoverMoves > 0);
+    state = await getState(page);
+    assert.ok(state.hoverMoves > 0, 'unselected zero-button hover must reach the 1003 TUI');
+
     // Native xterm force selection: Shift+drag selects and emits no PTY mouse
     // reports.
     await page.evaluate(() => window.fixture.pane.term.clearSelection());
@@ -382,35 +397,38 @@ async function run() {
     );
     await resetState(page);
     await page.keyboard.press('Control+c');
-    await page.waitForTimeout(300);
+    await page.waitForFunction(() => window.__nativeCopyEvents.length === 1);
     const keyboardCopyDebug = await page.evaluate(() => ({
       attempts: window.__copyAttempts,
+      nativeEvents: window.__nativeCopyEvents,
       selection: window.fixture.pane.term.getSelection(),
       activeClass: document.activeElement && document.activeElement.className,
-      helperSource: TerminalPane.copyTextToClipboard.toString().slice(0, 160),
     }));
     assert.strictEqual(
       keyboardCopyDebug.attempts.length,
-      1,
-      'selected Ctrl+C did not reach the copy helper: ' + JSON.stringify(keyboardCopyDebug)
+      0,
+      'selected Ctrl+C must bypass the explicit-action helper: ' +
+        JSON.stringify(keyboardCopyDebug)
     );
-    assert.notStrictEqual(keyboardCopyDebug.attempts[0].result, null);
+    assert.deepStrictEqual(
+      keyboardCopyDebug.nativeEvents,
+      [{ trusted: true, text: keyboardCopyText, defaultPrevented: true }],
+      'selected Ctrl+C must dispatch one trusted xterm copy event'
+    );
     state = await getState(page);
     assert.strictEqual(state.sigintCount, 0, 'selected Ctrl+C must not send ETX/SIGINT');
-    assert.deepStrictEqual(
-      await page.evaluate(() => window.__copyAttempts),
-      [{ text: keyboardCopyText, result: true }],
-      'selected Ctrl+C must attempt one successful copy with the exact selection'
-    );
     assert.strictEqual(await page.evaluate(() => navigator.clipboard.readText()), keyboardCopyText);
     assert.strictEqual(
-      (await readSelection(page)).hasSelection,
-      false,
-      'a confirmed keyboard copy must clear the copied selection'
+      (await readSelection(page)).text,
+      keyboardCopyText,
+      'native keyboard copy must retain the exact selection'
     );
 
-    // Caps Lock and Shift make KeyboardEvent.key uppercase. The normalized
-    // shortcut path must still copy a selection and must never leak ETX.
+    // Caps Lock can make KeyboardEvent.key uppercase without adding Shift.
+    // Playwright does not emulate lock-state casing, so dispatch an uppercase
+    // browser event to exercise xterm's real custom key handler. The trusted
+    // clipboard result is covered by the lowercase physical shortcut above;
+    // this case proves uppercase cannot leak ETX or invoke the async helper.
     const uppercaseCopyText = await page.evaluate(() => {
       const textarea = document.querySelector('#fixture-terminal .xterm-helper-textarea');
       window.__lastCopyShortcutKey = null;
@@ -425,9 +443,17 @@ async function run() {
     assert.ok(uppercaseCopyText, 'uppercase Ctrl+C scenario must start with a real selection');
     await page.locator('#fixture-terminal .xterm-helper-textarea').focus();
     await resetState(page);
-    await page.keyboard.press('Control+Shift+C');
-    await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
-      window.__copyAttempts[0].result !== null);
+    await page.evaluate(() => {
+      const textarea = document.querySelector('#fixture-terminal .xterm-helper-textarea');
+      textarea.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'C',
+        code: 'KeyC',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    await page.waitForTimeout(100);
     assert.strictEqual(
       await page.evaluate(() => window.__lastCopyShortcutKey),
       'C',
@@ -435,13 +461,13 @@ async function run() {
     );
     state = await getState(page);
     assert.strictEqual(state.sigintCount, 0, 'uppercase selected Ctrl+C must not send ETX/SIGINT');
-    assert.deepStrictEqual(
-      await page.evaluate(() => window.__copyAttempts),
-      [{ text: uppercaseCopyText, result: true }],
-      'uppercase selected Ctrl+C must copy the exact selection once'
-    );
+    assert.strictEqual(await page.evaluate(() => window.__nativeCopyEvents.length), 0,
+      'an untrusted synthetic key cannot claim a native clipboard result');
+    assert.strictEqual(await page.evaluate(() => window.__copyAttempts.length), 0);
+    assert.strictEqual((await readSelection(page)).text, uppercaseCopyText);
 
     // Unselected Ctrl+C still reaches the PTY exactly once.
+    await page.evaluate(() => window.fixture.pane.term.clearSelection());
     await page.locator('#fixture-terminal .xterm-helper-textarea').focus();
     await resetState(page);
     await page.keyboard.press('Control+c');
@@ -449,6 +475,7 @@ async function run() {
     state = await getState(page);
     assert.strictEqual(state.sigintCount, 1, 'unselected Ctrl+C must send one ETX/SIGINT');
     assert.strictEqual(await page.evaluate(() => window.__copyAttempts.length), 0);
+    assert.strictEqual(await page.evaluate(() => window.__nativeCopyEvents.length), 0);
 
     // Select mode converts a plain drag into a genuine selection, then turning
     // it off restores TUI mouse delivery.
@@ -466,6 +493,17 @@ async function run() {
       'Select mode selected the wrong terminal row: ' + JSON.stringify(selection.text)
     );
     assert.strictEqual(state.mouseEvents, 0, 'Select mode drag must not reach the TUI');
+    assert.strictEqual(
+      await page.evaluate(() => window.__focusCalls),
+      0,
+      'an already-active Select-mode drag must not refocus/refit the pane'
+    );
+    const selectModeCopyText = selection.text;
+    await page.keyboard.press('Control+c');
+    await page.waitForFunction(() => window.__nativeCopyEvents.length === 1);
+    assert.strictEqual(await page.evaluate(() => navigator.clipboard.readText()), selectModeCopyText);
+    assert.strictEqual((await readSelection(page)).text, selectModeCopyText);
+    assert.strictEqual((await getState(page)).sigintCount, 0);
     await selectModeButton.click();
     assert.strictEqual(await selectModeButton.getAttribute('aria-pressed'), 'false');
     await page.evaluate(() => window.fixture.pane.term.clearSelection());
@@ -480,14 +518,41 @@ async function run() {
     await dragCopyTarget(page, true);
     const rightClickSelection = (await readSelection(page)).text;
     await resetState(page);
+    const selectedHoverGeometry = await selectionGeometry(page);
+    await page.mouse.move(
+      selectedHoverGeometry.x2 + 40,
+      selectedHoverGeometry.y + 25,
+      { steps: 6 }
+    );
+    await page.waitForTimeout(100);
+    state = await getState(page);
+    assert.strictEqual(
+      state.hoverMoves,
+      0,
+      'zero-button hover after selection must not reach a 1003 mouse-reporting TUI'
+    );
+    assert.strictEqual(
+      (await readSelection(page)).text,
+      rightClickSelection,
+      'moving the pointer toward a right-click must preserve the exact selection'
+    );
     await openContextMenu(page);
     state = await getState(page);
     selection = await readSelection(page);
     assert.strictEqual(state.mouseEvents, 0, 'right-click on a selection must emit no PTY mouse event');
     assert.strictEqual(state.rightPresses, 0, 'right-click on a selection must not reach the TUI');
+    assert.strictEqual(
+      await page.evaluate(() => window.__focusCalls),
+      0,
+      'selected right-click must skip the earlier pane refocus that clears xterm selection'
+    );
     assert.strictEqual(selection.text, rightClickSelection, 'right-click must preserve the exact selection');
     const copyItem = page.locator('#fixture-context-menu [data-label="Copy"]');
     assert.strictEqual(await copyItem.count(), 1, 'production terminal menu must expose Copy');
+    // The action must use the contextmenu-time snapshot, not re-read a live
+    // selection that a later renderer/focus change may have cleared.
+    await page.evaluate(() => window.fixture.pane.term.clearSelection());
+    assert.strictEqual((await readSelection(page)).hasSelection, false);
     await copyItem.click();
     await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
       window.__copyAttempts[0].result !== null);
@@ -501,9 +566,10 @@ async function run() {
     );
     assert.strictEqual(await page.evaluate(() => navigator.clipboard.readText()), rightClickSelection);
 
-    // Clipboard denial through selected Ctrl+C must still consume the key,
-    // keep the recoverable selection, leave the native OS clipboard untouched,
-    // and surface a truthful error.
+    // Embedded browsers may expose navigator.clipboard while denying its
+    // programmatic write. Keyboard copy must not touch that API: Chromium's
+    // trusted copy event and xterm's synchronous clipboardData path still
+    // succeed, retain selection, and never emit SIGINT.
     await page.locator('#fixture-terminal .xterm-helper-textarea').focus();
     await resetState(page);
     const denialClipboardSentinel =
@@ -512,40 +578,74 @@ async function run() {
       const nativeClipboard = navigator.clipboard;
       await nativeClipboard.writeText(sentinel);
       window.__nativeClipboardForDenial = nativeClipboard;
+      window.__clipboardWriteAttempts = 0;
       Object.defineProperty(navigator, 'clipboard', {
         configurable: true,
-        value: { writeText: () => Promise.reject(new Error('denied')) },
+        value: {
+          writeText: () => {
+            window.__clipboardWriteAttempts += 1;
+            return Promise.reject(new Error('denied'));
+          },
+        },
       });
-      document.execCommand = () => false;
       window.fixture.pane.term.select(0, 1, 18);
     }, denialClipboardSentinel);
     const deniedKeyboardSelection = (await readSelection(page)).text;
     assert.ok(deniedKeyboardSelection, 'denial scenario must begin with a real xterm selection');
     await page.keyboard.press('Control+c');
-    await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
-      window.__copyAttempts[0].result === false && window.__toast !== null);
+    await page.waitForFunction(() => window.__nativeCopyEvents.length === 1);
     state = await getState(page);
-    assert.strictEqual(state.sigintCount, 0, 'failed selected Ctrl+C must never reach the PTY as SIGINT');
+    assert.strictEqual(state.sigintCount, 0, 'selected Ctrl+C must never reach the PTY as SIGINT');
     assert.strictEqual(
       (await readSelection(page)).text,
       deniedKeyboardSelection,
-      'failed selected Ctrl+C must preserve the exact selection'
+      'native selected Ctrl+C must preserve the exact selection'
     );
     assert.deepStrictEqual(
-      await page.evaluate(() => window.__toast),
-      { message: 'Copy was blocked by the browser. Selection kept.', level: 'error' }
+      await page.evaluate(() => window.__nativeCopyEvents),
+      [{ trusted: true, text: deniedKeyboardSelection, defaultPrevented: true }]
     );
     assert.strictEqual(
       await page.evaluate(() => window.__nativeClipboardForDenial.readText()),
-      denialClipboardSentinel,
-      'failed selected Ctrl+C must prevent Chromium/xterm native copy from changing the OS clipboard'
+      deniedKeyboardSelection,
+      'trusted native copy must replace the sentinel with the exact selection'
     );
+    assert.strictEqual(await page.evaluate(() => window.__clipboardWriteAttempts), 0,
+      'keyboard copy must not call navigator.clipboard.writeText');
+    assert.strictEqual(await page.evaluate(() => window.__copyAttempts.length), 0,
+      'keyboard copy must not call the explicit-action helper');
+    assert.strictEqual(await page.evaluate(() => window.__toast), null,
+      'successful native copy must not show a failure toast');
 
-    // The production right-click wrapper must remain truthful under the same
-    // denial and leave the selection available.
+    // The explicit right-click helper must preserve the trusted click by
+    // copying synchronously before the exposed-but-denied async API can expire
+    // user activation.
     await page.evaluate(() => {
       window.__copyAttempts.length = 0;
       window.__toast = null;
+    });
+    await openContextMenu(page);
+    await page.locator('#fixture-context-menu [data-label="Copy"]').click();
+    await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
+      window.__copyAttempts[0].result === true);
+    assert.deepStrictEqual(
+      await page.evaluate(() => window.__toast),
+      { message: 'Copied to clipboard', level: 'success' }
+    );
+    assert.strictEqual(await page.evaluate(() => window.__clipboardWriteAttempts), 0,
+      'successful synchronous menu copy must not call the denied Clipboard API');
+    assert.strictEqual(
+      await page.evaluate(() => window.__nativeClipboardForDenial.readText()),
+      deniedKeyboardSelection,
+      'gesture-preserving right-click Copy must write the exact selection'
+    );
+
+    // Under total denial the explicit helper remains truthful and leaves the
+    // selection available.
+    await page.evaluate(() => {
+      window.__copyAttempts.length = 0;
+      window.__toast = null;
+      document.execCommand = () => false;
     });
     await openContextMenu(page);
     await page.locator('#fixture-context-menu [data-label="Copy"]').click();
@@ -556,9 +656,15 @@ async function run() {
       { message: 'Copy failed', level: 'error' }
     );
     assert.strictEqual((await readSelection(page)).text, deniedKeyboardSelection);
+    assert.strictEqual(
+      await page.evaluate(() => window.__nativeClipboardForDenial.readText()),
+      deniedKeyboardSelection,
+      'failed explicit copy must not overwrite the last successful native copy'
+    );
     await page.evaluate(() => {
       delete navigator.clipboard;
       delete window.__nativeClipboardForDenial;
+      delete window.__clipboardWriteAttempts;
     });
 
     // Reload to restore the native Clipboard API, then prove the secure
@@ -772,11 +878,31 @@ async function run() {
       'real insecure-origin Ctrl+V must paste the platform clipboard text once'
     );
 
+    // Trusted keyboard copy must also work on a genuinely insecure origin,
+    // where navigator.clipboard is unavailable.
+    await dragCopyTarget(insecurePage, true);
+    const insecureCopyText = (await readSelection(insecurePage)).text;
+    await resetState(insecurePage);
+    await insecurePage.keyboard.press('Control+c');
+    await insecurePage.waitForFunction(() => window.__nativeCopyEvents.length === 1);
+    state = await getState(insecurePage);
+    assert.strictEqual(state.sigintCount, 0, 'insecure selected Ctrl+C must not emit SIGINT');
+    assert.deepStrictEqual(
+      await insecurePage.evaluate(() => window.__nativeCopyEvents),
+      [{ trusted: true, text: insecureCopyText, defaultPrevented: true }],
+      'insecure selected Ctrl+C must use the trusted native copy event'
+    );
+    assert.strictEqual(await insecurePage.evaluate(() => window.__copyAttempts.length), 0);
+    assert.strictEqual((await readSelection(insecurePage)).text, insecureCopyText);
+    assert.strictEqual(
+      await page.evaluate(() => navigator.clipboard.readText()),
+      insecureCopyText,
+      'secure-origin verification must read the exact insecure native copy'
+    );
+
     // The insecure-origin right-click action must use execCommand successfully
     // during its real click gesture, and the secure page must be able to read
     // the exact resulting clipboard contents.
-    await dragCopyTarget(insecurePage, true);
-    const insecureCopyText = (await readSelection(insecurePage)).text;
     await resetState(insecurePage);
     await openContextMenu(insecurePage);
     await insecurePage.locator('#fixture-context-menu [data-label="Copy"]').click();
@@ -821,12 +947,12 @@ async function run() {
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     console.log('PASS terminal browser acceptance');
     console.log('  Shift+drag: real selection, zero PTY mouse reports');
-    console.log('  Select mode: real selection; mode off restores TUI mouse events');
-    console.log('  Ctrl+C: lowercase/uppercase copy safely; denial retains selection; no SIGINT');
-    console.log('  Clipboard: denial leaves native contents unchanged; original formats restored');
-    console.log('  Right-click: preserved selection, zero TUI events, truthful copy toast');
+    console.log('  Select mode: real selection + native Ctrl+C; mode off restores TUI mouse events');
+    console.log('  Ctrl+C: trusted native copy; uppercase safety; denied API still works; no SIGINT');
+    console.log('  Clipboard: native copy writes exact text under API denial; original formats restored');
+    console.log('  Right-click: hover + both button edges preserve snapshot; truthful copy toast');
     console.log('  Paste: lowercase/uppercase, denied API, native, and orphan paths send exactly once');
-    console.log('  Insecure origin: guided menu + native paste; execCommand copy verified');
+    console.log('  Insecure origin: native Ctrl+C/paste plus execCommand menu copy verified');
     console.log('  Scroll: normal buffer scrolls; alternate-screen limitation confirmed');
     console.log('  Screenshot: ' + SCREENSHOT_PATH);
   } finally {

--- a/test/browser/workbook-shell.test.js
+++ b/test/browser/workbook-shell.test.js
@@ -277,8 +277,8 @@ async function run() {
     assert.strictEqual(shell.title, "myrlin's workbook");
     assert.strictEqual(shell.loginHidden, true, 'startup token must reveal the application shell');
     assert.strictEqual(shell.appHidden, false, 'application shell must be visible after startup auth');
-    assert.match(shell.terminalScript, /^terminal\.js\?v=20260725-copymode3-/);
-    assert.match(shell.appScript, /^app\.js\?v=20260725-copytruth-/);
+    assert.strictEqual(shell.terminalScript, 'terminal.js?v=20260725-copy-native5');
+    assert.strictEqual(shell.appScript, 'app.js?v=20260725-copy-native5');
     assert.strictEqual(shell.terminalClass, 'function', 'production TerminalPane must load');
     assert.strictEqual(shell.selectInterceptor, 'function', 'Select-mode interceptor must be present');
     assert.strictEqual(shell.themeRegistry, 'object', 'canonical theme registry must load before the app');
@@ -735,21 +735,6 @@ async function run() {
     );
     await classicPage.close();
 
-    // Exercise the listener installed by the real CWMApp._bindEvents rather
-    // than the lightweight terminal fixture's mirrored listener.
-    await page.evaluate(() => {
-      document.dispatchEvent(new CustomEvent('cwm:copy-unavailable', {
-        bubbles: true,
-        detail: { reason: 'failed', containerId: 'shell-proof', sessionId: 'shell-proof' },
-      }));
-    });
-    const copyFailureToast = page.locator('#toast-container .toast-error .toast-message').last();
-    await copyFailureToast.waitFor({ state: 'visible' });
-    assert.strictEqual(
-      await copyFailureToast.textContent(),
-      'Copy was blocked by the browser. Selection kept.',
-      'production app listener must render truthful Ctrl+C copy failure feedback'
-    );
     assert.deepStrictEqual(pageErrors, [], 'full Workbook page raised browser errors');
     const unexpectedExternalRequests = blockedExternalRequests.filter((requestUrl) => (
       !requestUrl.startsWith('https://fonts.googleapis.com/') &&
@@ -765,7 +750,6 @@ async function run() {
     console.log('  One-use startup auth succeeded and token was removed from the URL');
     console.log('  Focused desktop, tablet, mobile, light, and classic-density layouts rendered');
     console.log('  Secondary views routed through More; preview task tabs remained gated');
-    console.log('  Production copy-failure event listener rendered the truthful error');
     console.log('  External browser traffic was blocked; Git fetch and tunnel probes stayed inert');
     console.log('  No real profile, credential, session, or provider state was used');
     console.log('  Screenshots: ' + [

--- a/test/copy-secure-context-fallback.test.js
+++ b/test/copy-secure-context-fallback.test.js
@@ -3,42 +3,34 @@
  * Ctrl+C copy SIGINT regression gate (user report, 2026-07-24).
  * Modified: 2026-07-25
  *
- * The bug: the Ctrl+C branch of TerminalPane.attachCustomKeyEventHandler
- * called navigator.clipboard.writeText(...).catch(() => {}) directly. On an
- * insecure origin (plain http to a LAN IP or hostname, the documented
- * remote-access mode) navigator.clipboard is undefined, so the property
- * access threw a SYNCHRONOUS TypeError that .catch() could never intercept
- * (.catch only sees promise rejections, not a throw during property lookup).
- * The exception escaped the handler BEFORE clearSelection() and
- * `return false` executed, xterm treated the key as unhandled, and the
- * "copy" keystroke sent \x03 (SIGINT) that interrupted the user's running
- * CLI session. The copy itself also failed. Same secure-context trap as
- * paste issue #64, whose fix guarded the Ctrl+V branch but was never
- * applied to Ctrl+C.
+ * The original bug was an exception-prone async Clipboard API call inside the
+ * terminal key handler. A later fallback still canceled Chromium's trusted
+ * copy event with preventDefault(), so embedded browsers that denied
+ * navigator.clipboard.writeText could not use xterm's synchronous native copy
+ * handler even though that handler remained permitted.
  *
- * The fix under test:
- *   1. TerminalPane.copyTextToClipboard: feature-detects the writeText
- *      FUNCTION (not just the object) and otherwise copies through a
- *      temporary offscreen textarea + document.execCommand('copy'), which
- *      unlike programmatic paste is still permitted from script during a
- *      user gesture on every origin. Cleanup always runs in a finally.
- *      The helper never throws and its promise never rejects.
- *   2. The Ctrl+C branch routes through the helper inside a try/catch
- *      bracket so it ALWAYS reaches `return false` once a selection exists;
- *      the SIGINT fall-through is structurally impossible. It clears only
- *      after a successful copy; failure retains the selection and dispatches
- *      cwm:copy-unavailable for truthful user feedback.
- *   3. Every writeText call site in app.js routes through the helper (or
- *      the _copyWithToast wrapper); zero bare calls remain.
+ * The fix under test has two deliberately separate paths:
+ *   1. Keyboard Ctrl+C/Cmd+C asks getCopySelection(). When selected, it
+ *      returns false to xterm's key pipeline so ETX/SIGINT cannot reach the
+ *      PTY, but does not preventDefault, invoke an async helper, or clear the
+ *      selection. Chromium therefore dispatches the trusted `copy` event and
+ *      xterm synchronously fills ClipboardEvent.clipboardData.
+ *   2. Explicit menu/button copy actions still use
+ *      TerminalPane.copyTextToClipboard. That helper feature-detects
+ *      navigator.clipboard.writeText and falls back to an offscreen textarea
+ *      plus document.execCommand('copy') on insecure origins or permission
+ *      denial. It never throws or rejects.
+ *   3. Every writeText call site in app.js routes through that explicit-action
+ *      helper (or _copyWithToast); zero bare calls remain.
  *
  * Two layers of checks:
  *   - Source gates in the style of paste-secure-context-fallback.test.js
  *     (read the sources as text, string-match the load-bearing surface).
  *   - EXECUTED proofs: terminal.js is evaluated in a vm sandbox and the real
- *     extracted Ctrl+C branch is run with navigator.clipboard undefined,
- *     proving the branch still returns false (consumes the key, no SIGINT)
- *     and the text still lands on the stub clipboard via the execCommand
- *     fallback. This is what makes the gate non-vacuous.
+ *     extracted Ctrl+C branch is run with xterm and DOM selections, proving it
+ *     consumes selected keys without touching the permission-gated helper or
+ *     canceling the browser default. Real clipboard contents are verified in
+ *     terminal-interaction.test.js using Chromium's trusted event.
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */
@@ -159,6 +151,9 @@ function makeStubDocument(opts) {
       if (opts && opts.execThrows) throw new Error('execCommand blocked');
       const ta = body.children[body.children.length - 1];
       record.copiedValues.push(ta ? ta.value : null);
+      if (opts && Array.isArray(opts.execResults) && opts.execResults.length > 0) {
+        return opts.execResults.shift();
+      }
       return !(opts && opts.execFails);
     },
   };
@@ -205,12 +200,14 @@ async function main() {
     );
   });
 
-  await check('Ctrl+C branch routes through TerminalPane.copyTextToClipboard', () => {
+  await check('Ctrl+C branch reads the pane-scoped copy selection', () => {
     const branch = extractCtrlCBranch();
     assert.ok(
-      /copyTextToClipboard/.test(branch),
-      'the Ctrl+C branch must copy through the shared universal helper'
+      /const copySelection = this\.getCopySelection\(\)/.test(branch),
+      'the Ctrl+C branch must read xterm/native DOM selection through getCopySelection'
     );
+    assert.ok(/copySelection\.hasSelection\)\s*return false/.test(branch),
+      'a selected shortcut must return false before xterm can send ETX');
   });
 
   await check('copy/paste shortcuts normalize KeyboardEvent.key before safety branches', () => {
@@ -224,33 +221,16 @@ async function main() {
     );
   });
 
-  await check('Ctrl+C branch is structurally exception-proof (try before copy, catch before return false)', () => {
+  await check('Ctrl+C leaves Chromium native copy enabled and selection intact', () => {
     const branch = extractCtrlCBranch();
-    const tryIdx = branch.search(/try\s*\{/);
-    const selectionIdx = branch.indexOf('const selectedText = this.term.getSelection()');
-    const copyIdx = branch.indexOf('copyTextToClipboard');
-    const catchIdx = branch.search(/catch\s*\(/);
-    const retIdx = branch.lastIndexOf('return false;');
-    const preventIdx = branch.indexOf('e.preventDefault()');
-    assert.ok(tryIdx !== -1, 'branch must open a try block');
-    assert.ok(catchIdx !== -1, 'branch must have a catch clause');
-    assert.ok(preventIdx !== -1, 'selected Ctrl+C must cancel the browser native copy action');
-    assert.ok(tryIdx < preventIdx && preventIdx < copyIdx,
-      'preventDefault must run inside the selected branch before the custom clipboard helper');
-    assert.ok(tryIdx < selectionIdx, 'selection extraction must sit INSIDE the try block');
-    assert.ok(selectionIdx < copyIdx, 'the exact selection must be captured before the async copy');
-    assert.ok(tryIdx < copyIdx, 'the copy call must sit INSIDE the try block');
-    assert.ok(copyIdx < catchIdx, 'catch must close over the copy call');
-    assert.ok(catchIdx < retIdx, 'return false must come AFTER the catch, outside the bracket, so it always executes');
-    const protectedRegion = branch.slice(tryIdx, catchIdx);
-    assert.ok(/clearSelection/.test(protectedRegion),
-      'successful copy must still clear the selection inside the exception bracket');
-    assert.ok(/if\s*\(\s*copied\s*\)/.test(protectedRegion),
-      'clearSelection must be gated on the helper reporting success');
-    assert.ok(/_emitCopyUnavailable\('failed'\)/.test(branch),
-      'clipboard failure must dispatch a truthful user-visible notification');
-    assert.ok(/_selectionPositionKey/.test(branch),
-      'async success must compare the exact xterm selection range, not text alone');
+    assert.ok(!/preventDefault/.test(branch),
+      'preventDefault would disable Chromium/xterm trusted native copy');
+    assert.ok(!/copyTextToClipboard/.test(branch),
+      'keyboard copy must not depend on navigator.clipboard permission');
+    assert.ok(!/clearSelection/.test(branch),
+      'native copy keeps selection visible for retry and right-click');
+    assert.ok(!/_emitCopyUnavailable/.test(branch),
+      'native copy is synchronous browser behavior, not an async helper result');
   });
 
   // -------------------------------------------------------------------------
@@ -268,6 +248,10 @@ async function main() {
       "helper must check typeof navigator.clipboard.writeText === 'function' (an object check alone reintroduces the throw)"
     );
     assert.ok(/_copyViaExecCommand/.test(body), 'helper must fall back to _copyViaExecCommand');
+    assert.ok(
+      body.indexOf('_copyViaExecCommand') < body.indexOf('navigator.clipboard.writeText'),
+      'gesture-preserving execCommand copy must run before awaiting the Clipboard API'
+    );
   });
 
   await check('_copyViaExecCommand uses execCommand(copy) with cleanup in a finally', () => {
@@ -306,18 +290,23 @@ async function main() {
     assert.ok(/'error'/.test(body), '_copyWithToast must toast failures');
   });
 
-  await check('app.js surfaces cwm:copy-unavailable and says the selection was kept', () => {
-    const idx = appSrc.indexOf("document.addEventListener('cwm:copy-unavailable'");
-    assert.ok(idx !== -1, 'app.js must listen for Ctrl+C clipboard failures');
-    const body = appSrc.slice(idx, idx + 650);
-    assert.ok(/Selection kept/.test(body), 'the failure toast must tell the user the selection remains available');
-    assert.ok(/showToast\([^;]+,\s*'error'\)/s.test(body), 'clipboard failure must use an error toast');
+  await check('mobile Copy prefers pane-scoped DOM/xterm selection before the full buffer', () => {
+    const start = appSrc.indexOf("if (key === 'copy') {");
+    const end = appSrc.indexOf('// Full-screen reader overlay', start);
+    const body = start >= 0 && end > start ? appSrc.slice(start, end) : '';
+    assert.ok(body, 'mobile Copy branch not found');
+    const selectionIdx = body.indexOf('activePane.getCopySelection');
+    const bufferIdx = body.indexOf('activePane.term.buffer.active');
+    assert.ok(selectionIdx >= 0, 'mobile Copy must use getCopySelection');
+    assert.ok(bufferIdx > selectionIdx,
+      'full-buffer copy may run only after pane-scoped selection reports none');
   });
 
-  await check('index.html cache-busts the changed app.js copy-failure listener', () => {
+  await check('index.html cache-busts the changed native-copy scripts', () => {
     assert.ok(
-      /app\.js\?v=20260725-copytruth/.test(indexSrc),
-      'the changed app.js must not reuse a stale unversioned browser cache entry'
+      /terminal\.js\?v=20260725-copy-native5/.test(indexSrc) &&
+        /app\.js\?v=20260725-copy-native5/.test(indexSrc),
+      'native-copy and pane-event fixes must not reuse stale browser cache entries'
     );
   });
 
@@ -347,7 +336,7 @@ async function main() {
     assert.deepStrictEqual(record.execCalls, ['copy']);
   });
 
-  await check('helper: secure context uses writeText and resolves true without touching execCommand', async () => {
+  await check('helper: trusted click prefers synchronous copy before the async API', async () => {
     const { sandbox, TerminalPane } = loadTerminalPane();
     const written = [];
     sandbox.navigator = { clipboard: { writeText(v) { written.push(v); return Promise.resolve(); } } };
@@ -355,18 +344,30 @@ async function main() {
     sandbox.document = doc;
     const ok = await TerminalPane.copyTextToClipboard('secure path');
     assert.strictEqual(ok, true);
-    assert.deepStrictEqual(written, ['secure path'], 'writeText must receive the text on secure origins (behavior unchanged)');
-    assert.strictEqual(record.execCalls.length, 0, 'fallback must not run when writeText succeeded');
+    assert.deepStrictEqual(record.copiedValues, ['secure path']);
+    assert.deepStrictEqual(written, [], 'successful synchronous copy must preserve the gesture and skip writeText');
+  });
+
+  await check('helper: secure context uses writeText when synchronous copy is unavailable', async () => {
+    const { sandbox, TerminalPane } = loadTerminalPane();
+    const written = [];
+    sandbox.navigator = { clipboard: { writeText(v) { written.push(v); return Promise.resolve(); } } };
+    const { doc, record } = makeStubDocument({ execFails: true });
+    sandbox.document = doc;
+    const ok = await TerminalPane.copyTextToClipboard('async fallback');
+    assert.strictEqual(ok, true);
+    assert.deepStrictEqual(record.execCalls, ['copy']);
+    assert.deepStrictEqual(written, ['async fallback']);
   });
 
   await check('helper: writeText REJECTION falls back to execCommand instead of failing', async () => {
     const { sandbox, TerminalPane } = loadTerminalPane();
     sandbox.navigator = { clipboard: { writeText() { return Promise.reject(new Error('NotAllowedError')); } } };
-    const { doc, record } = makeStubDocument();
+    const { doc, record } = makeStubDocument({ execResults: [false, true] });
     sandbox.document = doc;
     const ok = await TerminalPane.copyTextToClipboard('denied then rescued');
     assert.strictEqual(ok, true, 'a permission denial should still copy via the gesture fallback');
-    assert.deepStrictEqual(record.copiedValues, ['denied then rescued']);
+    assert.deepStrictEqual(record.copiedValues, ['denied then rescued', 'denied then rescued']);
   });
 
   await check('helper: execCommand THROW still cleans up the textarea (finally) and resolves false', async () => {
@@ -389,55 +390,54 @@ async function main() {
   });
 
   // -------------------------------------------------------------------------
-  // (5) Executed proofs: the REAL Ctrl+C branch, insecure origin
+  // (5) Executed proofs: the REAL Ctrl+C native-copy branch
   // -------------------------------------------------------------------------
 
-  await check('REAL branch: navigator.clipboard undefined still returns false (key consumed, no SIGINT) and copies the selection', async () => {
-    const { sandbox, context } = loadTerminalPane();
-    delete sandbox.navigator; // the user-reported environment: plain http over LAN
-    const { doc, record } = makeStubDocument();
-    sandbox.document = doc;
-    const harness = compileCtrlCHarness(context);
+  await check('REAL branch: xterm selection consumes Ctrl+C without canceling native copy', () => {
+    const { sandbox, context, TerminalPane } = loadTerminalPane();
+    delete sandbox.navigator; // insecure origin: keyboard copy must not care
+    let helperCalls = 0;
     let cleared = 0;
     let prevented = 0;
-    const thisStub = {
-      term: {
-        hasSelection: () => true,
-        getSelection: () => 'SELECTED TEXT',
-        clearSelection: () => { cleared++; },
-      },
+    let selectionReads = 0;
+    TerminalPane.copyTextToClipboard = () => {
+      helperCalls++;
+      throw new Error('keyboard copy must never call the explicit-action helper');
     };
-    // With the OLD code this call THREW (TypeError on the property access)
-    // before return false, which is exactly how Ctrl+C reached the PTY as
-    // SIGINT. The assertion set below is therefore the whole bug in one run.
-    const result = harness.call(thisStub, {
+    const harness = compileCtrlCHarness(context);
+    const result = harness.call({
+      term: { clearSelection: () => { cleared++; } },
+      getCopySelection: () => {
+        selectionReads++;
+        return { hasSelection: true, text: 'SELECTED TEXT', source: 'xterm' };
+      },
+    }, {
       type: 'keydown',
       key: 'c',
       ctrlKey: true,
       metaKey: false,
       preventDefault: () => { prevented++; },
     }, true);
-    assert.strictEqual(result, false, 'branch must consume the key (return false); anything else falls through to SIGINT');
-    assert.strictEqual(prevented, 1, 'selected Ctrl+C must suppress the browser native copy path exactly once');
-    await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(cleared, 1, 'clearSelection must still run');
-    assert.deepStrictEqual(record.copiedValues, ['SELECTED TEXT'], 'the selection must actually land on the (stub) clipboard via the fallback');
+    assert.strictEqual(result, false, 'selected Ctrl+C must be withheld from ETX/SIGINT');
+    assert.strictEqual(selectionReads, 1, 'selection state must be read once');
+    assert.strictEqual(prevented, 0, 'Chromium native copy must remain enabled');
+    assert.strictEqual(helperCalls, 0, 'keyboard copy must bypass the async helper');
+    assert.strictEqual(cleared, 0, 'native copy must retain the selection');
   });
 
-  await check('REAL branch: uppercase Ctrl+C is consumed and copied instead of becoming SIGINT', async () => {
-    const { sandbox, context } = loadTerminalPane();
+  await check('REAL branch: uppercase Ctrl+C and native DOM selection are consumed safely', () => {
+    const { sandbox, context, TerminalPane } = loadTerminalPane();
     delete sandbox.navigator;
-    const { doc, record } = makeStubDocument();
-    sandbox.document = doc;
-    const harness = compileCtrlCHarness(context);
-    let cleared = 0;
+    let helperCalls = 0;
     let prevented = 0;
+    TerminalPane.copyTextToClipboard = () => { helperCalls++; return Promise.resolve(false); };
+    const harness = compileCtrlCHarness(context);
     const result = harness.call({
-      term: {
-        hasSelection: () => true,
-        getSelection: () => 'UPPERCASE SELECTED TEXT',
-        clearSelection: () => { cleared++; },
-      },
+      getCopySelection: () => ({
+        hasSelection: true,
+        text: 'VISIBLE DOM SELECTION',
+        source: 'dom',
+      }),
     }, {
       type: 'keydown',
       key: 'C',
@@ -447,82 +447,18 @@ async function main() {
       preventDefault: () => { prevented++; },
     }, true);
     assert.strictEqual(result, false, 'uppercase selected Ctrl+C must be consumed');
-    assert.strictEqual(prevented, 1, 'uppercase selected Ctrl+C must cancel native copy exactly once');
-    await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(cleared, 1, 'uppercase successful copy must clear the copied selection');
-    assert.deepStrictEqual(record.copiedValues, ['UPPERCASE SELECTED TEXT']);
+    assert.strictEqual(prevented, 0, 'uppercase copy must preserve the native default');
+    assert.strictEqual(helperCalls, 0, 'DOM-selection keyboard copy must remain native');
   });
 
-  await check('REAL branch: failed copy keeps selection, reports failure, and still consumes Ctrl+C', async () => {
-    const { sandbox, context } = loadTerminalPane();
-    delete sandbox.navigator;
-    delete sandbox.document; // scorched earth: every copy path unavailable
-    const harness = compileCtrlCHarness(context);
-    let cleared = 0;
-    let prevented = 0;
-    const notifications = [];
-    const thisStub = {
-      term: {
-        hasSelection: () => true,
-        getSelection: () => 'RECOVERABLE SELECTION',
-        clearSelection: () => { cleared++; },
-      },
-      _emitCopyUnavailable: (reason) => { notifications.push(reason); },
-    };
-    const result = harness.call(thisStub, {
-      type: 'keydown',
-      key: 'c',
-      ctrlKey: true,
-      metaKey: false,
-      preventDefault: () => { prevented++; },
-    }, true);
-    assert.strictEqual(result, false, 'the copy may fail, consuming the key may not');
-    assert.strictEqual(prevented, 1, 'failed selected Ctrl+C must still cancel the native copy path');
-    await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(cleared, 0, 'a failed copy must keep the selection so the user can recover it');
-    assert.deepStrictEqual(notifications, ['failed'], 'failed copy must emit exactly one notification');
-  });
-
-  await check('REAL branch: async success does not clear a newer equal-text selection at another range', async () => {
-    const { sandbox, context, TerminalPane } = loadTerminalPane();
-    let resolveCopy;
-    TerminalPane.copyTextToClipboard = () => new Promise((resolve) => { resolveCopy = resolve; });
-    sandbox.navigator = {};
-    const harness = compileCtrlCHarness(context);
-    let cleared = 0;
-    let position = {
-      start: { x: 1, y: 2 },
-      end: { x: 5, y: 2 },
-    };
-    const thisStub = {
-      term: {
-        hasSelection: () => true,
-        getSelection: () => 'SAME',
-        getSelectionPosition: () => position,
-        clearSelection: () => { cleared++; },
-      },
-      _emitCopyUnavailable: () => {},
-    };
-    const result = harness.call(thisStub, { type: 'keydown', key: 'c', ctrlKey: true, metaKey: false }, true);
-    assert.strictEqual(result, false, 'selected Ctrl+C must be consumed while the copy is pending');
-    position = {
-      start: { x: 12, y: 8 },
-      end: { x: 16, y: 8 },
-    };
-    resolveCopy(true);
-    await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(cleared, 0, 'equal text at a newer range must remain selected');
-  });
-
-  await check('REAL branch: no selection still falls through (plain Ctrl+C SIGINT preserved)', async () => {
+  await check('REAL branch: no selection still falls through (plain Ctrl+C SIGINT preserved)', () => {
     const { sandbox, context } = loadTerminalPane();
     delete sandbox.navigator;
     const harness = compileCtrlCHarness(context);
     let prevented = 0;
-    const thisStub = {
-      term: { hasSelection: () => false, getSelection: () => '', clearSelection: () => {} },
-    };
-    const result = harness.call(thisStub, {
+    const result = harness.call({
+      getCopySelection: () => ({ hasSelection: false, text: '', source: null }),
+    }, {
       type: 'keydown',
       key: 'c',
       ctrlKey: true,

--- a/test/data-provider-attr.test.js
+++ b/test/data-provider-attr.test.js
@@ -115,22 +115,25 @@ check('openTerminalInPane lookup falls back to \'claude\' on missing session', (
   );
 });
 
-// (5) Cleanup: fatal error path and closeTerminalPane both clear data-provider.
-check('fatal error path calls deadPane.removeAttribute(\'data-provider\')', () => {
+// (5) Cleanup: fatal error and close paths both route through the unified
+// fixed-host reset, which clears data-provider with the rest of the chrome.
+check('fatal error path resets its fixed host', () => {
+  const start = src.indexOf('  _handleTerminalPaneFatal(');
+  const end = src.indexOf('\n  openTerminalInPane(', start);
+  const body = src.slice(start, end);
   assert.ok(
-    /deadPane\.removeAttribute\(['"]data-provider['"]\)/.test(src),
-    'onFatalError must clear data-provider so an empty pane is not visually tagged'
+    /_resetTerminalPaneHost\(liveSlot\)/.test(body),
+    'fatal cleanup must reset the fixed host so an empty pane is not visually tagged'
   );
 });
 
-check('closeTerminalPane calls paneEl.removeAttribute(\'data-provider\')', () => {
-  // Confirm at least one paneEl.removeAttribute('data-provider') exists in the
-  // file. The pattern is unique enough that any closeTerminalPane refactor
-  // that drops the cleanup will fail this assertion.
-  const matches = src.match(/paneEl\.removeAttribute\(['"]data-provider['"]\)/g) || [];
+check('unified host reset clears data-provider', () => {
+  const start = src.indexOf('  _resetTerminalPaneHost(');
+  const end = src.indexOf('\n  _syncTerminalPaneHost(', start);
+  const body = src.slice(start, end);
   assert.ok(
-    matches.length >= 1,
-    'closeTerminalPane must clear data-provider so a closed pane is not visually tagged'
+    /paneEl\.removeAttribute\(['"]data-provider['"]\)/.test(body),
+    'fixed-host reset must clear data-provider so a closed pane is not visually tagged'
   );
 });
 

--- a/test/idle-notification-gating.test.js
+++ b/test/idle-notification-gating.test.js
@@ -88,6 +88,7 @@ function loadSandbox() {
   const doc = {
     documentElement: { dataset: {} },
     getElementById() { return container; },
+    dispatchEvent(ev) { container.events.push(ev); return true; },
   };
 
   const factory = new Function(
@@ -350,12 +351,16 @@ check('setActiveTerminalPane acknowledges completion without dismissing unresolv
 
 check('switchTerminalGroup re-points _activeTerminalSlot at the restored group', () => {
   assert.ok(
-    appSrc.includes('const firstFilledSlot = this.terminalPanes.findIndex(p => p);'),
-    'first filled slot lookup'
+    /let firstFilledSlot = -1;[\s\S]*this\._isSlotOccupied\(i\)[\s\S]*firstFilledSlot = i;/.test(appSrc),
+    'first occupied slot lookup must include terminals and mirrors'
   );
   assert.ok(
-    appSrc.includes('this._activeTerminalSlot = firstFilledSlot !== -1 ? firstFilledSlot : null;'),
-    'active slot assignment'
+    appSrc.includes('this._activeTerminalSlot = preferredActiveSlot !== null'),
+    'remembered active slot assignment'
+  );
+  assert.ok(
+    appSrc.includes(': (firstFilledSlot !== -1 ? firstFilledSlot : null);'),
+    'first filled slot fallback'
   );
 });
 

--- a/test/mirror-view-state.test.js
+++ b/test/mirror-view-state.test.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const source = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'web', 'public', 'mirror-view.js'),
+  'utf8'
+);
+const sandbox = {
+  window: {},
+  document: {},
+  console,
+  Number,
+  Math,
+  encodeURIComponent,
+  setTimeout,
+  clearTimeout,
+};
+vm.createContext(sandbox);
+vm.runInContext(
+  source + '\nthis.__MirrorPaneView = MirrorPaneView;',
+  sandbox,
+  { filename: 'mirror-view.js' }
+);
+const MirrorPaneView = sandbox.__MirrorPaneView;
+
+let passed = 0;
+let failed = 0;
+
+async function check(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log('  \x1b[32mPASS\x1b[0m ' + name);
+  } catch (err) {
+    failed++;
+    console.log('  \x1b[31mFAIL\x1b[0m ' + name);
+    console.log('       ' + (err && err.stack ? err.stack : String(err)));
+  }
+}
+
+(async () => {
+  console.log('\n  Mirror pane reading-position lifecycle');
+  console.log('  ' + '-'.repeat(58));
+
+  await check('descriptor records a scrolled-up reading position', () => {
+    const view = Object.create(MirrorPaneView.prototype);
+    view.provider = 'provider';
+    view.providerSessionId = 'session';
+    view.title = 'Read me';
+    view._elMessages = {
+      scrollHeight: 1200,
+      scrollTop: 175,
+      clientHeight: 300,
+    };
+
+    const descriptor = view.descriptor();
+    assert.strictEqual(descriptor.scrollState.pinnedToBottom, false);
+    assert.strictEqual(descriptor.scrollState.scrollTop, 175);
+  });
+
+  await check('initial reopen restores saved scroll instead of jumping to tail', async () => {
+    const view = Object.create(MirrorPaneView.prototype);
+    view._disposed = false;
+    view._openedOnce = false;
+    view._restoreScrollState = { pinnedToBottom: false, scrollTop: 210 };
+    view._renderSkeleton = () => {};
+    view._api = async () => ({
+      endOffset: 20,
+      startOffset: 0,
+      truncatedHead: false,
+      live: true,
+      history: [{ role: 'user', kind: 'text', text: 'history' }],
+    });
+    view._setLive = () => {};
+    view._renderMessagesHtml = () => '<div>history</div>';
+    view._updateLoadEarlier = () => {};
+    view._elMessages = {
+      innerHTML: '',
+      scrollHeight: 1000,
+      scrollTop: 0,
+      clientHeight: 300,
+    };
+
+    await view.open();
+    assert.strictEqual(view._elMessages.scrollTop, 210);
+    assert.strictEqual(view._restoreScrollState, null);
+  });
+
+  await check('pinned mirrors still reopen at the live tail', () => {
+    const view = Object.create(MirrorPaneView.prototype);
+    view._elMessages = {
+      scrollHeight: 900,
+      scrollTop: 0,
+      clientHeight: 300,
+    };
+    view._restoreScrollPosition({ pinnedToBottom: true, scrollTop: 12 });
+    assert.strictEqual(view._elMessages.scrollTop, 900);
+  });
+
+  console.log('  ' + '-'.repeat(58));
+  console.log(`  [mirror-view-state] ${passed}/${passed + failed} tests passed`);
+  process.exitCode = failed > 0 ? 1 : 0;
+})();

--- a/test/mobile-ux-fixes.test.js
+++ b/test/mobile-ux-fixes.test.js
@@ -414,7 +414,10 @@ check('P1-4: pane context menu offers Move to Tab...', () => {
   const body = methodBody(appJs, 'showTerminalContextMenu');
   assert.ok(body, 'showTerminalContextMenu must exist');
   assert.ok(/label: 'Move to Tab\.\.\.'/.test(body), 'Move to Tab entry missing');
-  assert.ok(/moveTerminalToGroup\(slotIdx, g\.id\)/.test(body), 'Move to Tab must call moveTerminalToGroup');
+  assert.ok(
+    /const liveSlot = resolveLiveOwnerSlot\(\);[\s\S]*moveTerminalToGroup\(liveSlot, g\.id\)/.test(body),
+    'Move to Tab must resolve and move the current TerminalPane owner'
+  );
   assert.ok(/g\.id !== this\._activeGroupId/.test(body), 'submenu must exclude the current group');
 });
 
@@ -460,8 +463,12 @@ check('P2: mobile terminal tab avoids nested buttons and names its close control
     'terminal selector and close controls must be sibling buttons'
   );
   assert.ok(
-    /class="terminal-tab-close"[\s\S]{0,200}aria-label="Close \$\{terminalName\} terminal"/.test(body),
-    'terminal close button must have a terminal-specific accessible name'
+    /class="terminal-tab-close"[\s\S]{0,200}aria-label="Close \$\{paneName\} pane"/.test(body),
+    'pane close button must have a pane-specific accessible name'
+  );
+  assert.ok(
+    /this\._mirrorPanes[\s\S]*activePanes\.push\(\{ idx: i, tp, mirror \}\)/.test(body),
+    'mobile pane selector must include standalone mirrors'
   );
   assert.ok(
     /querySelectorAll\('\.terminal-tab-item'\)[\s\S]{0,220}classList\.toggle\('active'/.test(

--- a/test/run.js
+++ b/test/run.js
@@ -940,8 +940,10 @@ const standaloneTests = [
   'codex-mirror-parse.test.js',      // issue #10 T1 P2: codex parseLine extraction + parseTranscript parity on canonical fixtures
   'mirror-service.test.js',          // issue #10 T1 P3: MirrorService open/close refcount, broadcast batching, limit, truncate reset, readEarlier paging
   'mirror-routes.test.js',           // issue #10 T1 P0+P3: /api/mirror routes, SSE deviceId scoping, discovery live/lastActiveMs flags
-  'copy-secure-context-fallback.test.js', // 2026-07-24 user report: Ctrl+C copy sent SIGINT on plain-http; universal copy helper + exception-proof branch + zero bare writeText gate
-  'terminal-select-mode.test.js', // 2026-07-25 mouse-mode copy fix: per-pane Select toggle (plain drag -> synthetic Shift+drag) + one-time Shift/Select hint, interceptor no-op when OFF
+  'mirror-view-state.test.js',       // 2026-07-25: mirror group-cycle preserves scrolled-up vs live-tail reading position
+  'copy-secure-context-fallback.test.js', // 2026-07-25: native selected Ctrl+C contract + explicit-action universal helper + zero bare writeText gate
+  'terminal-select-mode.test.js', // 2026-07-25: Select drag event ordering + selected hover/right-edge preservation + active/inactive focus execution
+  'terminal-host-ownership.test.js', // 2026-07-25 copy regression: moved/cached xterm owner + fixed-host listener/control/resize lifecycle
 ];
 
 let standaloneFailed = 0;

--- a/test/terminal-host-ownership.test.js
+++ b/test/terminal-host-ownership.test.js
@@ -1,0 +1,1398 @@
+#!/usr/bin/env node
+/**
+ * Terminal host ownership regression.
+ *
+ * Fixed grid slots are reused by drag/reorder and terminal-tab caching. The
+ * xterm DOM, selection, and WebSocket belong to a TerminalPane, while Select
+ * controls, capture listeners, and resize observation belong to the current
+ * fixed host. This test executes the production TerminalPane/CWMApp methods in
+ * a deterministic VM DOM so those two ownership domains cannot drift apart.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const TERMINAL_JS_PATH = path.join(__dirname, '..', 'src', 'web', 'public', 'terminal.js');
+const APP_JS_PATH = path.join(__dirname, '..', 'src', 'web', 'public', 'app.js');
+const terminalSource = fs.readFileSync(TERMINAL_JS_PATH, 'utf8');
+const appSource = fs.readFileSync(APP_JS_PATH, 'utf8');
+
+let passed = 0;
+let failed = 0;
+const pendingChecks = [];
+
+function pass(name) {
+  passed++;
+  console.log('  \x1b[32mPASS\x1b[0m ' + name);
+}
+
+function fail(name, err) {
+  failed++;
+  console.log('  \x1b[31mFAIL\x1b[0m ' + name);
+  console.log('       ' + (err && err.stack ? err.stack.split('\n').slice(0, 5).join('\n       ') : String(err)));
+}
+
+function check(name, fn) {
+  try {
+    const result = fn();
+    if (result && typeof result.then === 'function') {
+      pendingChecks.push(Promise.resolve(result).then(
+        () => pass(name),
+        err => fail(name, err)
+      ));
+    } else {
+      pass(name);
+    }
+  } catch (err) {
+    fail(name, err);
+  }
+}
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+    this.names = new Set();
+  }
+
+  replaceFromString(value) {
+    this.names = new Set(String(value || '').split(/\s+/).filter(Boolean));
+  }
+
+  add(...names) {
+    for (const name of names) this.names.add(name);
+    this.owner._className = [...this.names].join(' ');
+  }
+
+  remove(...names) {
+    for (const name of names) this.names.delete(name);
+    this.owner._className = [...this.names].join(' ');
+  }
+
+  contains(name) {
+    return this.names.has(name);
+  }
+
+  toggle(name, force) {
+    const shouldAdd = force === undefined ? !this.names.has(name) : !!force;
+    if (shouldAdd) this.add(name);
+    else this.remove(name);
+    return shouldAdd;
+  }
+}
+
+class FakeElement {
+  constructor(tagName = 'div', options = {}) {
+    this.nodeType = 1;
+    this.tagName = String(tagName).toUpperCase();
+    this.id = options.id || '';
+    this.children = [];
+    this.parentNode = null;
+    this.parentElement = null;
+    this.dataset = {};
+    this.style = {};
+    this.hidden = false;
+    this.textContent = '';
+    this.value = '';
+    this.blurCalls = 0;
+    this.focusCalls = 0;
+    this.attributes = new Map();
+    this.listeners = new Map();
+    this._innerHTML = '';
+    this._className = '';
+    this.classList = new FakeClassList(this);
+    this.className = options.className || '';
+  }
+
+  set className(value) {
+    this._className = String(value || '');
+    if (this.classList) this.classList.replaceFromString(this._className);
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value || '');
+    if (this._innerHTML === '') this.replaceChildren();
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  get childNodes() {
+    return this.children;
+  }
+
+  get firstChild() {
+    return this.children[0] || null;
+  }
+
+  appendChild(child) {
+    if (child && child.nodeType === 11) {
+      while (child.firstChild) this.appendChild(child.firstChild);
+      return child;
+    }
+    if (!child) return child;
+    if (child.parentNode) child.parentNode.removeChild(child);
+    this.children.push(child);
+    child.parentNode = this;
+    child.parentElement = this.nodeType === 1 ? this : null;
+    return child;
+  }
+
+  insertBefore(child, before) {
+    if (!before || !this.children.includes(before)) return this.appendChild(child);
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const index = this.children.indexOf(before);
+    this.children.splice(index, 0, child);
+    child.parentNode = this;
+    child.parentElement = this;
+    return child;
+  }
+
+  removeChild(child) {
+    const index = this.children.indexOf(child);
+    if (index !== -1) this.children.splice(index, 1);
+    child.parentNode = null;
+    child.parentElement = null;
+    return child;
+  }
+
+  replaceChildren(...children) {
+    for (const child of [...this.children]) this.removeChild(child);
+    for (const child of children) this.appendChild(child);
+  }
+
+  remove() {
+    if (this.parentNode) this.parentNode.removeChild(this);
+  }
+
+  contains(node) {
+    if (node === this) return true;
+    return this.children.some(child => child.contains && child.contains(node));
+  }
+
+  matches(selector) {
+    if (selector.startsWith('.')) return this.classList.contains(selector.slice(1));
+    if (selector.startsWith('#')) return this.id === selector.slice(1);
+    return this.tagName.toLowerCase() === selector.toLowerCase();
+  }
+
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (current.matches && current.matches(selector)) return current;
+      current = current.parentElement;
+    }
+    return null;
+  }
+
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (child.matches && child.matches(selector)) return child;
+      const nested = child.querySelector && child.querySelector(selector);
+      if (nested) return nested;
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    const matches = [];
+    for (const child of this.children) {
+      if (child.matches && child.matches(selector)) matches.push(child);
+      if (child.querySelectorAll) matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+
+  count(selector) {
+    let total = 0;
+    for (const child of this.children) {
+      if (child.matches && child.matches(selector)) total++;
+      if (child.count) total += child.count(selector);
+    }
+    return total;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+    if (name.startsWith('data-')) {
+      const key = name.slice(5).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      delete this.dataset[key];
+    }
+  }
+
+  addEventListener(type, handler, options) {
+    const capture = options === true || !!(options && options.capture);
+    const key = `${type}:${capture ? 'capture' : 'bubble'}`;
+    const handlers = this.listeners.get(key) || [];
+    if (!handlers.includes(handler)) handlers.push(handler);
+    this.listeners.set(key, handlers);
+  }
+
+  removeEventListener(type, handler, options) {
+    const capture = options === true || !!(options && options.capture);
+    const key = `${type}:${capture ? 'capture' : 'bubble'}`;
+    const handlers = (this.listeners.get(key) || []).filter(candidate => candidate !== handler);
+    this.listeners.set(key, handlers);
+  }
+
+  listenerCount(type, capture = true) {
+    return (this.listeners.get(`${type}:${capture ? 'capture' : 'bubble'}`) || []).length;
+  }
+
+  dispatchEvent() {
+    return true;
+  }
+
+  blur() {
+    this.blurCalls++;
+  }
+
+  focus() {
+    this.focusCalls++;
+  }
+}
+
+class FakeFragment extends FakeElement {
+  constructor() {
+    super('fragment');
+    this.nodeType = 11;
+    this.tagName = '';
+  }
+}
+
+class FakeDocument {
+  constructor() {
+    this.nodesById = new Map();
+    this.documentElement = new FakeElement('html');
+    this.documentElement.dataset = {};
+    this.body = new FakeElement('body');
+    this.activeElement = this.body;
+  }
+
+  register(node) {
+    if (node.id) this.nodesById.set(node.id, node);
+    for (const child of node.children) this.register(child);
+    return node;
+  }
+
+  getElementById(id) {
+    return this.nodesById.get(id) || null;
+  }
+
+  querySelector() {
+    return null;
+  }
+
+  querySelectorAll() {
+    return [];
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName);
+  }
+
+  createDocumentFragment() {
+    return new FakeFragment();
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  getSelection() { return null; }
+}
+
+class FakeResizeObserver {
+  constructor() {
+    this.observeCalls = [];
+    this.disconnectCalls = 0;
+    this.current = null;
+  }
+
+  observe(node) {
+    this.observeCalls.push(node);
+    this.current = node;
+  }
+
+  disconnect() {
+    this.disconnectCalls++;
+    this.current = null;
+  }
+}
+
+function createSlot(document, slot) {
+  const pane = new FakeElement('section', {
+    id: `term-pane-${slot}`,
+    className: 'terminal-pane',
+  });
+  const header = new FakeElement('header', { className: 'terminal-pane-header' });
+  const title = new FakeElement('span', { className: 'terminal-pane-title' });
+  const providerPill = new FakeElement('span', { className: 'pane-provider-pill' });
+  const activity = new FakeElement('span', {
+    id: `term-activity-${slot}`,
+    className: 'terminal-pane-activity',
+  });
+  const micButton = new FakeElement('button', { className: 'terminal-pane-mic' });
+  const expandButton = new FakeElement('button', { className: 'terminal-pane-expand' });
+  const collapseButton = new FakeElement('button', { className: 'terminal-pane-collapse' });
+  const closeButton = new FakeElement('button', { className: 'terminal-pane-close' });
+  const viewBadge = new FakeElement('span', { className: 'pane-view-badge' });
+  const viewBackButton = new FakeElement('button', { className: 'pane-view-back' });
+  header.appendChild(title);
+  header.appendChild(providerPill);
+  header.appendChild(activity);
+  header.appendChild(micButton);
+  header.appendChild(expandButton);
+  header.appendChild(collapseButton);
+  const pinButton = new FakeElement('button', { className: 'terminal-pane-pinnedoc' });
+  const pinCount = new FakeElement('span', { className: 'pane-pin-count' });
+  pinButton.appendChild(pinCount);
+  header.appendChild(pinButton);
+  header.appendChild(closeButton);
+  header.appendChild(viewBadge);
+  header.appendChild(viewBackButton);
+  const container = new FakeElement('div', {
+    id: `term-container-${slot}`,
+    className: 'terminal-container',
+  });
+  const viewContainer = new FakeElement('div', {
+    id: `pane-view-${slot}`,
+    className: 'pane-view-container',
+  });
+  viewContainer.hidden = true;
+  const uploadButton = new FakeElement('button', { className: 'terminal-pane-upload' });
+  const scheduleButton = new FakeElement('button', { className: 'terminal-pane-schedule' });
+  const scheduleCount = new FakeElement('span', { className: 'pane-schedule-count' });
+  scheduleButton.appendChild(scheduleCount);
+  const mobileInputRow = new FakeElement('div', { className: 'terminal-mobile-input-row' });
+  mobileInputRow.appendChild(new FakeElement('input', { className: 'mobile-type-input' }));
+  mobileInputRow.appendChild(new FakeElement('button', { className: 'mobile-send-btn' }));
+  const mobileToolbar = new FakeElement('div', { className: 'terminal-mobile-toolbar' });
+  mobileToolbar.appendChild(new FakeElement('button', { className: 'toolbar-keyboard' }));
+  pane.appendChild(header);
+  pane.appendChild(container);
+  pane.appendChild(viewContainer);
+  pane.appendChild(uploadButton);
+  pane.appendChild(scheduleButton);
+  pane.appendChild(mobileInputRow);
+  pane.appendChild(mobileToolbar);
+  document.register(pane);
+  return {
+    pane,
+    header,
+    title,
+    providerPill,
+    activity,
+    micButton,
+    expandButton,
+    collapseButton,
+    closeButton,
+    pinButton,
+    pinCount,
+    viewBadge,
+    viewBackButton,
+    container,
+    viewContainer,
+    uploadButton,
+    scheduleButton,
+    scheduleCount,
+    mobileInputRow,
+    mobileInput: mobileInputRow.querySelector('.mobile-type-input'),
+    mobileToolbar,
+    keyboardButton: mobileToolbar.querySelector('.toolbar-keyboard'),
+  };
+}
+
+function loadProductionRuntime(document, options = {}) {
+  const animationFrames = [];
+  let animationFrameId = 0;
+  const window = {
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() {},
+    matchMedia: () => ({ matches: false }),
+    getComputedStyle: () => ({ getPropertyValue: () => '' }),
+  };
+  const sandbox = {
+    window,
+    document,
+    navigator: { platform: 'Win32' },
+    localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+    location: { protocol: 'http:', host: 'test.invalid' },
+    console: { log() {}, warn() {}, error() {}, debug() {} },
+    setTimeout: () => 1,
+    clearTimeout() {},
+    setInterval: () => 1,
+    clearInterval() {},
+    requestAnimationFrame(callback) {
+      const id = ++animationFrameId;
+      if (options.deferAnimationFrames) {
+        animationFrames.push({ id, callback });
+      } else {
+        callback();
+      }
+      return id;
+    },
+    cancelAnimationFrame(id) {
+      const index = animationFrames.findIndex(frame => frame.id === id);
+      if (index !== -1) animationFrames.splice(index, 1);
+    },
+    fetch: () => Promise.resolve({ json: () => Promise.resolve({ status: 'ok' }) }),
+    ErrorEvent: function ErrorEvent(type, init) { this.type = type; Object.assign(this, init); },
+    MouseEvent: function MouseEvent(type, init) { this.type = type; Object.assign(this, init); },
+    CustomEvent: function CustomEvent(type, init) { this.type = type; Object.assign(this, init); },
+    ResizeObserver: FakeResizeObserver,
+    CSS: { escape: value => String(value) },
+  };
+  window.document = document;
+  window.location = sandbox.location;
+  vm.createContext(sandbox);
+  vm.runInContext(terminalSource, sandbox, { filename: 'terminal.js' });
+  vm.runInContext(appSource + '\nwindow.__TestCWMApp = CWMApp;', sandbox, { filename: 'app.js' });
+  return {
+    TerminalPane: sandbox.window.TerminalPane,
+    CWMApp: sandbox.window.__TestCWMApp,
+    flushNextAnimationFrame() {
+      const frame = animationFrames.shift();
+      if (frame) frame.callback();
+      return !!frame;
+    },
+    flushAllAnimationFrames() {
+      while (animationFrames.length) animationFrames.shift().callback();
+    },
+    get pendingAnimationFrames() {
+      return animationFrames.length;
+    },
+  };
+}
+
+function makeLivePane(TerminalPane, host, options = {}) {
+  const selection = { text: options.selection || '' };
+  const xtermRoot = new FakeElement('div', { className: 'xterm' });
+  host.container.appendChild(xtermRoot);
+  const term = {
+    element: xtermRoot,
+    rows: 24,
+    refreshCalls: 0,
+    clearSelectionCalls: 0,
+    focusCalls: 0,
+    blurCalls: 0,
+    hasSelection: () => selection.text.length > 0,
+    getSelection: () => selection.text,
+    clearSelection() {
+      this.clearSelectionCalls++;
+      selection.text = '';
+    },
+    refresh() { this.refreshCalls++; },
+    focus() { this.focusCalls++; },
+    blur() { this.blurCalls++; },
+  };
+  const ws = {
+    closeCalls: 0,
+    close() { this.closeCalls++; },
+  };
+  const pane = new TerminalPane(
+    host.container.id,
+    options.sessionId || 'session',
+    options.sessionName || 'Terminal',
+    { provider: options.provider || 'claude' }
+  );
+  pane.term = term;
+  pane.ws = ws;
+  pane._resizeObserver = new FakeResizeObserver();
+  pane._isMobile = () => false;
+  pane._maybeShowCopyHint = () => {};
+  pane._updateSelectModeUI = () => {};
+  pane.activate = () => {};
+  pane.safeFit = () => {};
+  assert.strictEqual(pane.rebindHost(host.container.id), true, 'initial host bind');
+  return { pane, term, ws, selection, xtermRoot };
+}
+
+function makeDeferredPane(document, slot, options = {}) {
+  const pane = {
+    containerId: `term-container-${slot}`,
+    paneEl: document.getElementById(`term-pane-${slot}`),
+    sessionId: options.sessionId || `deferred-${slot}`,
+    sessionName: options.sessionName || `Deferred ${slot}`,
+    spawnOpts: { provider: options.provider || 'claude' },
+    _providerId: options.provider || 'claude',
+    _mountActivationGeneration: 0,
+    _currentActivity: options.activity || null,
+    term: null,
+    mountCalls: 0,
+    disposeCalls: 0,
+    rebindCalls: [],
+    detachCalls: 0,
+    focusCalls: 0,
+    blurCalls: 0,
+    safeFitCalls: 0,
+    activateCalls: 0,
+    focusedStates: [],
+    mount() {
+      this.mountCalls++;
+      const root = new FakeElement('div', { className: 'xterm' });
+      root.__cwmTerminalPane = this;
+      const container = document.getElementById(this.containerId);
+      if (container) container.appendChild(root);
+      this.term = {
+        element: root,
+        rows: 24,
+        refreshCalls: 0,
+        refresh() { this.refreshCalls++; },
+      };
+    },
+    dispose() {
+      this.disposeCalls++;
+      if (this.term && this.term.element) this.term.element.remove();
+      this.term = null;
+    },
+    rebindHost(containerId) {
+      this.rebindCalls.push(containerId);
+      this.containerId = containerId;
+      this.paneEl = document.getElementById(containerId.replace('container', 'pane'));
+      const container = document.getElementById(containerId);
+      if (container && this.term && this.term.element) {
+        container.appendChild(this.term.element);
+      }
+      return !!container;
+    },
+    detachHostBindings() {
+      this.detachCalls++;
+      return true;
+    },
+    setFocused(value) {
+      this._isFocused = !!value;
+      this.focusedStates.push(!!value);
+    },
+    focus() { this.focusCalls++; },
+    blur() { this.blurCalls++; },
+    safeFit() { this.safeFitCalls++; },
+    activate() { this.activateCalls++; },
+  };
+  return pane;
+}
+
+function makeLifecycleApp(CWMApp, options = {}) {
+  const app = Object.create(CWMApp.prototype);
+  const size = CWMApp.MAX_PANES;
+  app.terminalPanes = new Array(size).fill(null);
+  (options.panes || []).forEach((pane, index) => {
+    app.terminalPanes[index] = pane;
+  });
+  app._activeGroupId = options.activeGroupId || 'group-a';
+  app._activeTerminalSlot = options.activeSlot === undefined
+    ? 0
+    : options.activeSlot;
+  app._tabGroups = options.groups || [
+    { id: 'group-a', name: 'A', panes: [] },
+    { id: 'group-b', name: 'B', panes: [] },
+  ];
+  app._groupPaneCache = {};
+  app._mirrorPanes = new Array(size).fill(null);
+  app._voiceRecognitions = {};
+  app._paneRefreshTimers = {};
+  app._paneViewGenerations = new Array(size).fill(0);
+  app._gridColSizes = [1, 1];
+  app._gridRowSizes = [1, 1];
+  app._speechRecognitionAvailable = false;
+  app._getProviderById = id => ({ displayName: String(id).toUpperCase() });
+  app._renderCodexStatusStrip = () => {};
+  app.updateTerminalGridLayout = () => {};
+  app.renderTerminalGroupTabs = () => {};
+  app._ensureActiveTabVisible = () => {};
+  app.saveTerminalLayout = () => {};
+  app.saveCurrentGroupPanes = () => {};
+  app.showToast = () => {};
+  app._activationCalls = [];
+  app.setActiveTerminalPane = slot => {
+    app._activeTerminalSlot = slot;
+    app._activationCalls.push(slot);
+  };
+  return app;
+}
+
+function assertSingleHostBinding(host) {
+  assert.strictEqual(host.header.count('.terminal-pane-selectmode'), 1, 'one Select control');
+  assert.strictEqual(host.container.listenerCount('mousedown'), 1, 'one mousedown interceptor');
+  assert.strictEqual(host.container.listenerCount('mousemove'), 1, 'one mousemove interceptor');
+  assert.strictEqual(host.container.listenerCount('mouseup'), 1, 'one mouseup interceptor');
+}
+
+function assertNoHostBinding(host) {
+  assert.strictEqual(host.header.count('.terminal-pane-selectmode'), 0, 'no stale Select control');
+  assert.strictEqual(host.container.listenerCount('mousedown'), 0, 'no stale mousedown interceptor');
+  assert.strictEqual(host.container.listenerCount('mousemove'), 0, 'no stale mousemove interceptor');
+  assert.strictEqual(host.container.listenerCount('mouseup'), 0, 'no stale mouseup interceptor');
+}
+
+console.log('\n  Terminal host ownership lifecycle');
+console.log('  ' + '-'.repeat(58));
+
+check('stamped xterm event owner beats a stale fixed-slot array entry', () => {
+  const document = new FakeDocument();
+  const host = createSlot(document, 0);
+  const { CWMApp } = loadProductionRuntime(document);
+  const stampedOwner = { id: 'rendered-owner' };
+  const staleSlotOwner = { id: 'stale-slot-owner' };
+  const xtermRoot = new FakeElement('div', { className: 'xterm' });
+  const child = new FakeElement('span');
+  xtermRoot.__cwmTerminalPane = stampedOwner;
+  xtermRoot.appendChild(child);
+  host.container.appendChild(xtermRoot);
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [staleSlotOwner];
+
+  assert.strictEqual(
+    app._terminalPaneFromPointerEvent(0, { target: child }),
+    stampedOwner,
+    'event routing must follow the stamped rendered terminal'
+  );
+});
+
+check('context-menu pane actions use the stamped owner slot coherently', () => {
+  const document = new FakeDocument();
+  createSlot(document, 0);
+  createSlot(document, 1);
+  const { CWMApp } = loadProductionRuntime(document);
+  const staleSlotOwner = {
+    sessionId: 'stale',
+    sessionName: 'Stale',
+    spawnOpts: {},
+  };
+  const renderedOwner = {
+    sessionId: 'rendered',
+    sessionName: 'Rendered',
+    spawnOpts: {},
+    pasteFromClipboard() {},
+    focus() {},
+    sendCommand() {},
+  };
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [staleSlotOwner, renderedOwner];
+  app.state = {};
+  app._tabGroups = [];
+  app._activeGroupId = null;
+  app._buildSessionContextItems = () => null;
+  app.getSessionConflicts = () => [];
+  let renderedItems = null;
+  const closedSlots = [];
+  app._renderContextItems = (_title, items) => { renderedItems = items; };
+  app.closeTerminalPane = slot => { closedSlots.push(slot); };
+
+  app.showTerminalContextMenu(
+    0,
+    10,
+    20,
+    { hasSelection: true, text: 'OWNER TEXT', source: 'xterm' },
+    renderedOwner
+  );
+  const closeItem = renderedItems.find(item => item && item.label === 'Close Pane');
+  assert.ok(closeItem, 'production menu must expose Close Pane');
+  closeItem.action();
+  assert.deepStrictEqual(
+    closedSlots,
+    [1],
+    'slot-owning actions must follow the stamped owner, never the stale listener slot'
+  );
+});
+
+check('detach/rebind transfers host resources without touching selection or WebSocket', () => {
+  const document = new FakeDocument();
+  const host0 = createSlot(document, 0);
+  const host1 = createSlot(document, 1);
+  const { TerminalPane } = loadProductionRuntime(document);
+  const live = makeLivePane(TerminalPane, host0, { selection: 'keep this text' });
+  assertSingleHostBinding(host0);
+
+  const sameSocket = live.pane.ws;
+  assert.strictEqual(live.pane.detachHostBindings(), true);
+  assertNoHostBinding(host0);
+  assert.strictEqual(live.pane._resizeObserver.current, null, 'old resize host disconnected');
+  assert.strictEqual(live.pane.getCopySelection().text, 'keep this text');
+  assert.strictEqual(live.term.clearSelectionCalls, 0);
+  assert.strictEqual(live.ws.closeCalls, 0);
+
+  assert.strictEqual(live.pane.rebindHost(host1.container.id), true);
+  assertNoHostBinding(host0);
+  assertSingleHostBinding(host1);
+  assert.strictEqual(live.pane.containerId, host1.container.id);
+  assert.strictEqual(live.pane.paneEl, host1.pane);
+  assert.strictEqual(live.xtermRoot.parentElement, host1.container);
+  assert.strictEqual(live.xtermRoot.__cwmTerminalPane, live.pane);
+  assert.strictEqual(live.pane._resizeObserver.current, host1.container);
+  assert.strictEqual(live.pane.getCopySelection().text, 'keep this text');
+  assert.strictEqual(live.pane.ws, sameSocket);
+  assert.strictEqual(live.ws.closeCalls, 0);
+});
+
+check('swapTerminalPanes rebinds both moved terminals and keeps owner/container coherent', () => {
+  const document = new FakeDocument();
+  const host0 = createSlot(document, 0);
+  const host1 = createSlot(document, 1);
+  const { TerminalPane, CWMApp } = loadProductionRuntime(document);
+  const left = makeLivePane(TerminalPane, host0, {
+    sessionId: 'left',
+    selection: 'LEFT SELECTION',
+    provider: 'codex',
+  });
+  const right = makeLivePane(TerminalPane, host1, {
+    sessionId: 'right',
+    selection: 'RIGHT SELECTION',
+    provider: 'claude',
+  });
+  left.pane._currentActivity = { type: 'writing' };
+  right.pane._currentActivity = { type: 'reading' };
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [left.pane, right.pane];
+  app._activeTerminalSlot = 0;
+  app._voiceRecognitions = {};
+  app._mirrorPanes = {};
+  app._paneRefreshTimers = {};
+  app._paneViewGenerations = [0, 0];
+  app._speechRecognitionAvailable = false;
+  app._renderCodexStatusStrip = () => {};
+  app._getProviderById = id => ({ displayName: id.toUpperCase() });
+  app.updateTerminalGridLayout = () => {};
+  app.saveTerminalLayout = () => {};
+
+  app.swapTerminalPanes(0, 1);
+
+  assert.strictEqual(app.terminalPanes[0], right.pane);
+  assert.strictEqual(app.terminalPanes[1], left.pane);
+  assert.strictEqual(right.pane.containerId, host0.container.id);
+  assert.strictEqual(right.pane.paneEl, host0.pane);
+  assert.strictEqual(right.xtermRoot.parentElement, host0.container);
+  assert.strictEqual(right.xtermRoot.__cwmTerminalPane, right.pane);
+  assert.strictEqual(left.pane.containerId, host1.container.id);
+  assert.strictEqual(left.pane.paneEl, host1.pane);
+  assert.strictEqual(left.xtermRoot.parentElement, host1.container);
+  assert.strictEqual(left.xtermRoot.__cwmTerminalPane, left.pane);
+  assert.strictEqual(host0.pane.dataset.provider, 'claude');
+  assert.strictEqual(host1.pane.dataset.provider, 'codex');
+  assertSingleHostBinding(host0);
+  assertSingleHostBinding(host1);
+  assert.strictEqual(left.pane.getCopySelection().text, 'LEFT SELECTION');
+  assert.strictEqual(right.pane.getCopySelection().text, 'RIGHT SELECTION');
+  assert.strictEqual(left.ws.closeCalls + right.ws.closeCalls, 0);
+  assert.strictEqual(app._activeTerminalSlot, 1, 'active owner follows the moved pane');
+  assert.strictEqual(left.pane._isFocused, true, 'moved active pane keeps foreground rendering');
+  assert.strictEqual(right.pane._isFocused, false, 'other pane is demoted');
+  assert.strictEqual(
+    host0.activity.dataset.activityKey,
+    'reading|',
+    'destination host restores the activity owned by the pane moved into it'
+  );
+  assert.strictEqual(
+    host1.activity.dataset.activityKey,
+    'writing|',
+    'source host restores the activity owned by the pane moved into it'
+  );
+});
+
+check('cached group detach/restore is idempotent and preserves live terminal ownership', () => {
+  const document = new FakeDocument();
+  const host = createSlot(document, 0);
+  const { TerminalPane, CWMApp } = loadProductionRuntime(document);
+  const live = makeLivePane(TerminalPane, host, {
+    sessionId: 'cached',
+    selection: 'CACHED SELECTION',
+    provider: 'codex',
+  });
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [live.pane, null, null, null, null, null];
+  app._mirrorPanes = new Array(CWMApp.MAX_PANES).fill(null);
+  app._groupPaneCache = {};
+  app._activeGroupId = 'group-a';
+  app._activeTerminalSlot = 0;
+  app._tabGroups = [
+    { id: 'group-a', name: 'A', panes: [] },
+    { id: 'group-b', name: 'B', panes: [] },
+  ];
+  app.saveCurrentGroupPanes = () => {};
+  app.updateTerminalGridLayout = () => {};
+  app.renderTerminalGroupTabs = () => {};
+  app._ensureActiveTabVisible = () => {};
+  app.saveTerminalLayout = () => {};
+  app._restoreGroupMirrorPanes = () => {};
+  app._getProviderById = id => ({ displayName: id.toUpperCase() });
+  app._renderCodexStatusStrip = () => {};
+  app._voiceRecognitions = {};
+  app._paneRefreshTimers = {};
+  app._paneViewGenerations = new Array(CWMApp.MAX_PANES).fill(0);
+  app.openTerminalInPane = () => { throw new Error('cache restore must not reconnect'); };
+  live.pane._isFocused = true;
+  live.pane._needsInput = true;
+  live.pane._currentActivity = { type: 'searching' };
+
+  app.switchTerminalGroup('group-b');
+  assertNoHostBinding(host);
+  assert.strictEqual(host.activity.innerHTML, '', 'shared host activity is empty while its owner is cached');
+  assert.ok(app._groupPaneCache['group-a'], 'outgoing live group cached');
+  assert.strictEqual(live.pane.getCopySelection().text, 'CACHED SELECTION');
+  assert.strictEqual(live.ws.closeCalls, 0);
+  assert.strictEqual(live.xtermRoot.__cwmTerminalPane, live.pane);
+  assert.strictEqual(live.pane._isFocused, false, 'cached pane is background-throttled');
+
+  app.switchTerminalGroup('group-a');
+  assert.strictEqual(app.terminalPanes[0], live.pane);
+  assert.strictEqual(live.xtermRoot.parentElement, host.container);
+  assert.strictEqual(live.xtermRoot.__cwmTerminalPane, live.pane);
+  assert.strictEqual(live.pane.containerId, host.container.id);
+  assert.strictEqual(live.pane.paneEl, host.pane);
+  assertSingleHostBinding(host);
+  assert.strictEqual(live.pane.getCopySelection().text, 'CACHED SELECTION');
+  assert.strictEqual(live.ws.closeCalls, 0);
+  assert.strictEqual(live.pane._isFocused, true, 'remembered active pane is promoted');
+  assert.strictEqual(
+    host.header.dataset.needsInput,
+    'true',
+    'unresolved needs-input badge is restored with its TerminalPane'
+  );
+  assert.strictEqual(
+    host.activity.dataset.activityKey,
+    'searching|',
+    'cached pane activity is restored onto its rebound host'
+  );
+
+  // A second full cycle proves controls/listeners do not accumulate.
+  app.switchTerminalGroup('group-b');
+  app.switchTerminalGroup('group-a');
+  assertSingleHostBinding(host);
+  assert.strictEqual(live.pane.getCopySelection().text, 'CACHED SELECTION');
+  assert.strictEqual(live.xtermRoot.__cwmTerminalPane, live.pane);
+  assert.strictEqual(live.pane._resizeObserver.current, host.container);
+  assert.strictEqual(live.ws.closeCalls, 0);
+});
+
+check('A to B to A remembers a selected mirror instead of activating a hidden terminal', () => {
+  const document = new FakeDocument();
+  const hosts = [];
+  for (let slot = 0; slot < 6; slot++) hosts.push(createSlot(document, slot));
+  const runtime = loadProductionRuntime(document, { deferAnimationFrames: true });
+  const live = makeLivePane(runtime.TerminalPane, hosts[0], {
+    sessionId: 'terminal-a',
+  });
+  live.pane.activateCalls = 0;
+  live.pane.activate = () => { live.pane.activateCalls++; };
+  const groups = [
+    {
+      id: 'group-a',
+      name: 'A',
+      panes: [
+        { slot: 0, sessionId: 'terminal-a', sessionName: 'Terminal A' },
+        {
+          slot: 1,
+          sessionId: null,
+          viewType: 'mirror',
+          viewData: {
+            provider: 'codex',
+            providerSessionId: 'mirror-a',
+            title: 'Mirror A',
+          },
+        },
+      ],
+    },
+    { id: 'group-b', name: 'B', panes: [] },
+  ];
+  const app = makeLifecycleApp(runtime.CWMApp, {
+    panes: [live.pane],
+    activeGroupId: 'group-a',
+    activeSlot: 1,
+    groups,
+  });
+  app._mirrorPanes[1] = {
+    title: 'Mirror A',
+    dispose() {},
+    descriptor() { return groups[0].panes[1].viewData; },
+  };
+  app._restoreGroupMirrorPanes = group => {
+    for (const record of (group && group.panes) || []) {
+      if (record.viewType !== 'mirror') continue;
+      app._mirrorPanes[record.slot] = {
+        title: record.viewData.title,
+        dispose() {},
+        descriptor() { return record.viewData; },
+      };
+    }
+  };
+
+  app.switchTerminalGroup('group-b');
+  app.switchTerminalGroup('group-a');
+
+  assert.strictEqual(
+    app._activeTerminalSlot,
+    1,
+    'remembered mirror slot is restored after its descriptor is reopened'
+  );
+  runtime.flushAllAnimationFrames();
+  assert.strictEqual(
+    live.pane.activateCalls,
+    0,
+    'cached repaint must not activate the hidden terminal behind a selected mirror'
+  );
+});
+
+check('deferred mount is cancelled by a group switch and by close', () => {
+  {
+    const document = new FakeDocument();
+    for (let slot = 0; slot < 6; slot++) createSlot(document, slot);
+    const runtime = loadProductionRuntime(document, { deferAnimationFrames: true });
+    const pane = makeDeferredPane(document, 0, { sessionId: 'switch-cancel' });
+    const app = makeLifecycleApp(runtime.CWMApp, {
+      panes: [pane],
+      activeGroupId: 'group-a',
+      activeSlot: 0,
+    });
+
+    app._mountTerminalPaneOnNextFrame(pane, 'group-a', true);
+    app.switchTerminalGroup('group-b');
+    runtime.flushAllAnimationFrames();
+
+    assert.strictEqual(pane.mountCalls, 0, 'switch-away must cancel the old group mount');
+    assert.deepStrictEqual(app._activationCalls, [], 'switch-away must cancel stale activation');
+    assert.strictEqual(
+      app._groupPaneCache['group-a'].panes[0],
+      pane,
+      'the unmounted pane remains cached for a later legitimate restore'
+    );
+  }
+
+  {
+    const document = new FakeDocument();
+    for (let slot = 0; slot < 6; slot++) createSlot(document, slot);
+    const runtime = loadProductionRuntime(document, { deferAnimationFrames: true });
+    const pane = makeDeferredPane(document, 0, { sessionId: 'close-cancel' });
+    const app = makeLifecycleApp(runtime.CWMApp, {
+      panes: [pane],
+      activeGroupId: 'group-a',
+      activeSlot: 0,
+    });
+
+    app._mountTerminalPaneOnNextFrame(pane, 'group-a', true);
+    app.closeTerminalPane(0);
+    runtime.flushAllAnimationFrames();
+
+    assert.strictEqual(pane.disposeCalls, 1, 'close disposes the pending pane');
+    assert.strictEqual(pane.mountCalls, 0, 'closed pane must not mount on the queued frame');
+    assert.strictEqual(app.terminalPanes[0], null, 'closed slot remains empty');
+    assert.deepStrictEqual(app._activationCalls, [], 'closed pane cannot reclaim focus');
+  }
+});
+
+check('deferred mount follows TerminalPane identity through a same-group swap', () => {
+  const document = new FakeDocument();
+  for (let slot = 0; slot < 6; slot++) createSlot(document, slot);
+  const runtime = loadProductionRuntime(document, { deferAnimationFrames: true });
+  const pane = makeDeferredPane(document, 0, {
+    sessionId: 'swap-before-mount',
+    provider: 'codex',
+  });
+  const app = makeLifecycleApp(runtime.CWMApp, {
+    panes: [pane],
+    activeGroupId: 'group-a',
+    activeSlot: 0,
+  });
+
+  app._mountTerminalPaneOnNextFrame(pane, 'group-a', true);
+  app.swapTerminalPanes(0, 1);
+  runtime.flushNextAnimationFrame();
+
+  assert.strictEqual(app.terminalPanes[0], null);
+  assert.strictEqual(app.terminalPanes[1], pane);
+  assert.strictEqual(pane.mountCalls, 1, 'pane mounts exactly once after its move');
+  assert.strictEqual(pane.containerId, 'term-container-1', 'mount resolves the moved owner slot');
+  assert.strictEqual(
+    pane.term.element.parentElement,
+    document.getElementById('term-container-1'),
+    'new xterm root lands in the moved destination host'
+  );
+  assert.deepStrictEqual(app._activationCalls, [1], 'activation follows the moved owner identity');
+});
+
+check('A to B to A cannot let stale unconditional mount override remembered active pane', () => {
+  const document = new FakeDocument();
+  for (let slot = 0; slot < 6; slot++) createSlot(document, slot);
+  const runtime = loadProductionRuntime(document, { deferAnimationFrames: true });
+  const staleOpen = makeDeferredPane(document, 0, { sessionId: 'stale-open' });
+  const rememberedActive = makeDeferredPane(document, 1, { sessionId: 'remembered-active' });
+  const app = makeLifecycleApp(runtime.CWMApp, {
+    panes: [staleOpen, rememberedActive],
+    activeGroupId: 'group-a',
+    activeSlot: 1,
+  });
+
+  // This is the unconditional frame queued by the initial open in A.
+  app._mountTerminalPaneOnNextFrame(staleOpen, 'group-a', true);
+  app.switchTerminalGroup('group-b');
+  app.switchTerminalGroup('group-a');
+  assert.strictEqual(app._activeTerminalSlot, 1, 'cache restore remembers pane 1 before frames run');
+
+  runtime.flushAllAnimationFrames();
+
+  assert.strictEqual(staleOpen.mountCalls, 1, 'stale-open pane may still construct once after A returns');
+  assert.strictEqual(rememberedActive.mountCalls, 1, 'remembered active pane constructs once');
+  assert.deepStrictEqual(
+    app._activationCalls,
+    [1],
+    'invalidated unconditional activation cannot steal focus from remembered pane 1'
+  );
+  assert.strictEqual(app._activeTerminalSlot, 1);
+  assert.strictEqual(staleOpen._isFocused, false);
+  assert.strictEqual(rememberedActive._isFocused, true);
+});
+
+check('_resetTerminalPaneHost clears every fixed-slot lifecycle surface', () => {
+  const document = new FakeDocument();
+  const host = createSlot(document, 0);
+  const { CWMApp } = loadProductionRuntime(document);
+  const app = Object.create(CWMApp.prototype);
+  let mirrorDisposeCalls = 0;
+  let voiceAbortCalls = 0;
+  let codexStripCalls = 0;
+  const interimOverlay = new FakeElement('div', { className: 'voice-interim-overlay' });
+  host.pane.appendChild(interimOverlay);
+  const recognition = {
+    _cwmSlot: 0,
+    _cwmMicButton: host.micButton,
+    _cwmInterimOverlay: interimOverlay,
+    abort() { voiceAbortCalls++; },
+  };
+  app._voiceRecognitions = { 0: recognition };
+  app._mirrorPanes = {
+    0: { dispose() { mirrorDisposeCalls++; } },
+  };
+  app._paneRefreshTimers = { 0: 123 };
+  app._paneViewGenerations = [7, 0, 0, 0, 0, 0];
+  app._renderCodexStatusStrip = () => { codexStripCalls++; };
+
+  host.pane.classList.add(
+    'terminal-pane-active',
+    'pane-expanded-stage1',
+    'pane-expanded-stage2',
+    'pane-nav-pulse',
+    'terminal-pane-dragging',
+    'drag-over',
+    'terminal-pane-loading',
+    'terminal-pane-done'
+  );
+  host.pane.classList.remove('terminal-pane-empty');
+  Object.assign(host.pane.dataset, {
+    provider: 'codex',
+    attentionState: 'needs-input',
+    needsInput: 'true',
+    viewType: 'doc',
+    viewData: '{"docId":"readme"}',
+  });
+  host.header.classList.add('attention-state');
+  host.header.dataset.attentionState = 'needs-input';
+  host.header.dataset.needsInput = 'true';
+  host.title.textContent = 'Busy pane';
+  host.providerPill.hidden = false;
+  host.providerPill.textContent = 'Codex';
+  host.providerPill.dataset.provider = 'codex';
+  [
+    host.closeButton,
+    host.uploadButton,
+    host.expandButton,
+    host.collapseButton,
+    host.micButton,
+    host.pinButton,
+    host.scheduleButton,
+  ].forEach(control => { control.hidden = false; });
+  host.expandButton.classList.add('terminal-pane-expand-stage1', 'terminal-pane-expand-stage2');
+  host.expandButton.title = 'Expand to full screen';
+  host.micButton.classList.add('mic-active');
+  host.scheduleCount.textContent = '4';
+  host.scheduleCount.hidden = false;
+  host.pinCount.textContent = '2';
+  host.viewBadge.hidden = false;
+  host.viewBadge.textContent = 'Markdown';
+  host.viewBackButton.hidden = false;
+  host.viewContainer.hidden = false;
+  host.viewContainer.appendChild(new FakeElement('article'));
+  host.container.hidden = true;
+  host.container.appendChild(new FakeElement('div', { className: 'xterm' }));
+  host.mobileInputRow.classList.add('active');
+  host.mobileInput.value = 'unsent draft';
+  document.activeElement = host.mobileInput;
+  host.keyboardButton.classList.add('toolbar-active');
+  host.keyboardButton.textContent = '\u2328 Typing';
+  host.activity.dataset.activityKey = 'writing|file.js';
+  host.activity.innerHTML = 'Writing: file.js';
+
+  assert.strictEqual(app._resetTerminalPaneHost(0), true);
+
+  assert.strictEqual(recognition._cwmDiscarded, true);
+  assert.strictEqual(voiceAbortCalls, 1);
+  assert.strictEqual(app._voiceRecognitions[0], undefined);
+  assert.strictEqual(interimOverlay.parentNode, null);
+  assert.strictEqual(mirrorDisposeCalls, 1);
+  assert.strictEqual(app._mirrorPanes[0], undefined);
+  assert.strictEqual(app._paneRefreshTimers[0], undefined);
+  assert.strictEqual(app._paneViewGenerations[0], 8);
+  assert.strictEqual(host.pane.classList.contains('terminal-pane-empty'), true);
+  for (const className of [
+    'terminal-pane-active',
+    'pane-expanded-stage1',
+    'pane-expanded-stage2',
+    'pane-nav-pulse',
+    'terminal-pane-dragging',
+    'drag-over',
+    'terminal-pane-loading',
+    'terminal-pane-done',
+  ]) {
+    assert.strictEqual(host.pane.classList.contains(className), false, `${className} cleared`);
+  }
+  assert.strictEqual(host.pane.dataset.provider, undefined);
+  assert.strictEqual(host.pane.dataset.attentionState, undefined);
+  assert.strictEqual(host.pane.dataset.needsInput, undefined);
+  assert.strictEqual(host.pane.dataset.viewType, undefined);
+  assert.strictEqual(host.pane.dataset.viewData, undefined);
+  assert.strictEqual(host.header.classList.contains('attention-state'), false);
+  assert.strictEqual(host.header.dataset.attentionState, undefined);
+  assert.strictEqual(host.header.dataset.needsInput, undefined);
+  assert.strictEqual(host.title.textContent, 'Drop a session here');
+  assert.strictEqual(host.providerPill.hidden, true);
+  assert.strictEqual(host.providerPill.textContent, '');
+  assert.strictEqual(host.providerPill.dataset.provider, undefined);
+  [
+    host.closeButton,
+    host.uploadButton,
+    host.expandButton,
+    host.collapseButton,
+    host.micButton,
+    host.pinButton,
+    host.scheduleButton,
+  ].forEach(control => assert.strictEqual(control.hidden, true));
+  assert.strictEqual(host.expandButton.classList.contains('terminal-pane-expand-stage1'), false);
+  assert.strictEqual(host.expandButton.classList.contains('terminal-pane-expand-stage2'), false);
+  assert.strictEqual(host.expandButton.title, 'Expand pane');
+  assert.strictEqual(host.micButton.classList.contains('mic-active'), false);
+  assert.strictEqual(host.scheduleCount.textContent, '');
+  assert.strictEqual(host.scheduleCount.hidden, true);
+  assert.strictEqual(host.pinCount.textContent, '');
+  assert.strictEqual(host.viewBadge.hidden, true);
+  assert.strictEqual(host.viewBadge.textContent, '');
+  assert.strictEqual(host.viewBackButton.hidden, true);
+  assert.strictEqual(host.viewContainer.hidden, true);
+  assert.strictEqual(host.viewContainer.children.length, 0);
+  assert.strictEqual(host.container.hidden, false);
+  assert.strictEqual(host.container.children.length, 0);
+  assert.strictEqual(host.mobileInputRow.classList.contains('active'), false);
+  assert.strictEqual(host.mobileInput.value, '');
+  assert.strictEqual(host.mobileInput.blurCalls, 1);
+  assert.strictEqual(host.keyboardButton.classList.contains('toolbar-active'), false);
+  assert.strictEqual(host.keyboardButton.textContent, '\u2328 Type');
+  assert.strictEqual(host.activity.innerHTML, '');
+  assert.strictEqual(host.activity.dataset.activityKey, undefined);
+  assert.strictEqual(codexStripCalls, 1);
+});
+
+check('fatal error in cached group disposes pane and removes its persisted descriptor', () => {
+  const document = new FakeDocument();
+  const { CWMApp } = loadProductionRuntime(document);
+  const app = Object.create(CWMApp.prototype);
+  const deadPane = {
+    sessionId: 'dead-session',
+    disposeCalls: 0,
+    dispose() { this.disposeCalls++; },
+  };
+  const survivor = { sessionId: 'survivor' };
+  const cachedPanes = new Array(CWMApp.MAX_PANES).fill(null);
+  const fragments = new Array(CWMApp.MAX_PANES).fill(null);
+  cachedPanes[2] = deadPane;
+  cachedPanes[4] = survivor;
+  fragments[2] = { id: 'dead-fragment' };
+  app.terminalPanes = new Array(CWMApp.MAX_PANES).fill(null);
+  app._groupPaneCache = {
+    'group-a': {
+      panes: cachedPanes,
+      domFragments: fragments,
+      activePane: deadPane,
+      activeSlot: 2,
+    },
+  };
+  app._tabGroups = [{
+    id: 'group-a',
+    panes: [
+      { slot: 2, sessionId: 'dead-session', sessionName: 'Dead' },
+      { slot: 4, sessionId: 'survivor', sessionName: 'Survivor' },
+    ],
+  }];
+  let saveCalls = 0;
+  app.saveTerminalLayout = () => { saveCalls++; };
+
+  assert.strictEqual(app._handleTerminalPaneFatal(deadPane), true);
+  assert.strictEqual(deadPane.disposeCalls, 1);
+  assert.strictEqual(cachedPanes[2], null);
+  assert.strictEqual(fragments[2], null);
+  assert.strictEqual(app._groupPaneCache['group-a'].activePane, survivor);
+  assert.strictEqual(app._groupPaneCache['group-a'].activeSlot, 4);
+  assert.deepStrictEqual(
+    app._tabGroups[0].panes.map(record => record.sessionId),
+    ['survivor'],
+    'fatal cached session descriptor is removed without touching siblings'
+  );
+  assert.strictEqual(saveCalls, 1);
+});
+
+check('auto-trust setting propagates to live and cached panes in both directions', () => {
+  const document = new FakeDocument();
+  const { CWMApp } = loadProductionRuntime(document);
+  const live = {
+    _autoTrustEnabled: false,
+    smoothCalls: 0,
+    applySmoothScrollSetting() { this.smoothCalls++; },
+  };
+  const cachedA = {
+    _autoTrustEnabled: false,
+    smoothCalls: 0,
+    applySmoothScrollSetting() { this.smoothCalls++; },
+  };
+  const cachedB = {
+    _autoTrustEnabled: false,
+    smoothCalls: 0,
+    applySmoothScrollSetting() { this.smoothCalls++; },
+  };
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [live, null];
+  app._groupPaneCache = {
+    a: { panes: [cachedA, null] },
+    b: { panes: [null, cachedB] },
+  };
+  app.state = { settings: { autoTrustDialogs: true } };
+  app.els = {};
+  app.getSetting = () => false;
+  app._sidebarTasksMode = 'native';
+  app._activeTasksTab = 'worktree';
+  app.renderWorkspaces = null;
+  app.loadTdIssues = null;
+
+  app.applySettings();
+  assert.strictEqual(live._autoTrustEnabled, true);
+  assert.strictEqual(cachedA._autoTrustEnabled, true);
+  assert.strictEqual(cachedB._autoTrustEnabled, true);
+
+  app.state.settings.autoTrustDialogs = false;
+  app.applySettings();
+  assert.strictEqual(live._autoTrustEnabled, false);
+  assert.strictEqual(cachedA._autoTrustEnabled, false);
+  assert.strictEqual(cachedB._autoTrustEnabled, false);
+  assert.strictEqual(live.smoothCalls, 2);
+  assert.strictEqual(cachedA.smoothCalls, 2);
+  assert.strictEqual(cachedB.smoothCalls, 2);
+});
+
+check('mobile A to B to A keeps keyboard state scoped to each pane input row', () => {
+  const document = new FakeDocument();
+  const hostA = createSlot(document, 0);
+  const hostB = createSlot(document, 1);
+  const { CWMApp } = loadProductionRuntime(document);
+  const paneA = { safeFitCalls: 0, safeFit() { this.safeFitCalls++; } };
+  const paneB = { safeFitCalls: 0, safeFit() { this.safeFitCalls++; } };
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [paneA, paneB];
+  app._activeTerminalSlot = 0;
+  app.els = { terminalTabStrip: null };
+  app.setActiveTerminalPane = slot => { app._activeTerminalSlot = slot; };
+
+  hostA.mobileInputRow.classList.add('active');
+  hostA.keyboardButton.classList.add('toolbar-active');
+  hostA.keyboardButton.textContent = '\u2328 Typing';
+  hostB.keyboardButton.textContent = '\u2328 Type';
+
+  app.switchTerminalTab(1);
+  assert.strictEqual(hostB.keyboardButton.classList.contains('toolbar-active'), false);
+  assert.strictEqual(hostB.keyboardButton.textContent, '\u2328 Type');
+  assert.strictEqual(
+    hostA.keyboardButton.textContent,
+    '\u2328 Typing',
+    'switching to B does not mirror B state into A toolbar'
+  );
+
+  app.switchTerminalTab(0);
+  assert.strictEqual(hostA.keyboardButton.classList.contains('toolbar-active'), true);
+  assert.strictEqual(hostA.keyboardButton.textContent, '\u2328 Typing');
+  assert.strictEqual(hostB.keyboardButton.classList.contains('toolbar-active'), false);
+  assert.strictEqual(hostB.keyboardButton.textContent, '\u2328 Type');
+  assert.strictEqual(paneA.safeFitCalls, 1);
+  assert.strictEqual(paneB.safeFitCalls, 1);
+});
+
+check('mobile mirror selection overrides a stale visible terminal class', () => {
+  const document = new FakeDocument();
+  const terminalHost = createSlot(document, 0);
+  createSlot(document, 1);
+  const { CWMApp } = loadProductionRuntime(document);
+  const strip = new FakeElement('div');
+  terminalHost.pane.classList.add('mobile-active');
+  const app = Object.create(CWMApp.prototype);
+  Object.defineProperty(app, 'isMobile', { value: true });
+  app.terminalPanes = [{ sessionName: 'Terminal' }, null];
+  app._mirrorPanes = [null, {
+    title: 'Mirror',
+    providerSessionId: 'mirror-session',
+  }];
+  app._activeTerminalSlot = 1;
+  app.els = { terminalTabStrip: strip };
+  app.state = { sessions: [], hiddenSessions: new Set() };
+  app.escapeHtml = value => String(value);
+  let switchedTo = null;
+  app.switchTerminalTab = slot => { switchedTo = slot; };
+
+  app.updateTerminalTabs();
+  assert.strictEqual(
+    switchedTo,
+    1,
+    'explicitly opened mirror wins over the previous terminal mobile-active class'
+  );
+});
+
+check('mobile mirror hides terminal-only controls and terminal restores them', () => {
+  const document = new FakeDocument();
+  const terminalHost = createSlot(document, 0);
+  const mirrorHost = createSlot(document, 1);
+  const { CWMApp } = loadProductionRuntime(document);
+  const terminal = { safeFit() {} };
+  const app = Object.create(CWMApp.prototype);
+  app.terminalPanes = [terminal, null];
+  app._mirrorPanes = [null, { title: 'Mirror' }];
+  app._activeTerminalSlot = 0;
+  app.els = { terminalTabStrip: null };
+  app.setActiveTerminalPane = slot => { app._activeTerminalSlot = slot; };
+
+  app.switchTerminalTab(1);
+  assert.strictEqual(mirrorHost.mobileToolbar.hidden, true);
+  assert.strictEqual(mirrorHost.mobileInputRow.hidden, true);
+  assert.strictEqual(
+    mirrorHost.mobileInputRow.classList.contains('active'),
+    false
+  );
+
+  app.switchTerminalTab(0);
+  assert.strictEqual(terminalHost.mobileToolbar.hidden, false);
+  assert.strictEqual(terminalHost.mobileInputRow.hidden, false);
+});
+
+Promise.all(pendingChecks).then(() => {
+  console.log('  ' + '-'.repeat(58));
+  console.log(`  [terminal-host-ownership] ${passed}/${passed + failed} tests passed`);
+  process.exitCode = failed > 0 ? 1 : 0;
+});

--- a/test/terminal-select-mode.test.js
+++ b/test/terminal-select-mode.test.js
@@ -36,8 +36,10 @@ const vm = require('vm');
 const assert = require('assert');
 
 const TERMINAL_JS_PATH = path.join(__dirname, '..', 'src', 'web', 'public', 'terminal.js');
+const APP_JS_PATH = path.join(__dirname, '..', 'src', 'web', 'public', 'app.js');
 const INDEX_HTML_PATH = path.join(__dirname, '..', 'src', 'web', 'public', 'index.html');
 const termSrc = fs.readFileSync(TERMINAL_JS_PATH, 'utf8');
+const appSrc = fs.readFileSync(APP_JS_PATH, 'utf8');
 const indexSrc = fs.readFileSync(INDEX_HTML_PATH, 'utf8');
 
 let passed = 0;
@@ -75,7 +77,38 @@ check('interceptor forces selection via a shiftKey-true synthetic clone', () => 
 
 check('interceptor steers left drags and preserves selected-text right-click', () => {
   assert.ok(/e\.button\s*!==\s*0/.test(termSrc), 'expected a left-button-only guard');
-  assert.ok(/hasSelection\(\)/.test(termSrc), 'expected a selected-text right-click guard');
+  assert.ok(/getCopySelection\(\)\.hasSelection/.test(termSrc),
+    'expected the right-click/hover guard to use the pane-scoped copy selection');
+  assert.ok(/selectedHover/.test(termSrc), 'expected selected hover suppression');
+  assert.ok(/selectedRightEdge/.test(termSrc), 'expected both right-button edges to be suppressed');
+});
+
+check('pane capture focus skips a selected-text right-button press', () => {
+  assert.ok(
+    /_focusTerminalPaneFromPointer\s*\(slotIdx,\s*event\)/.test(appSrc),
+    'pane mousedown listener must delegate through the selection-aware focus helper'
+  );
+  const start = appSrc.indexOf('  _focusTerminalPaneFromPointer(slotIdx, event) {');
+  const end = appSrc.indexOf('\n  setActiveTerminalPane(slotIdx) {', start);
+  const body = start >= 0 && end > start ? appSrc.slice(start, end) : '';
+  assert.ok(body, 'expected _focusTerminalPaneFromPointer method body');
+  assert.ok(
+    /getCopySelection\(\)/.test(body),
+    'right-button focus guard must consult the pane-scoped live selection'
+  );
+  assert.ok(
+    /selectedRightPress[\s\S]*stopPropagation[\s\S]*return false/.test(body),
+    'selected right press must stop before app-level activation'
+  );
+  assert.ok(
+    body.indexOf('if (selectedRightPress)') <
+      body.indexOf('this.setActiveTerminalPane(focusSlot)'),
+    'selected right press must return before setActiveTerminalPane'
+  );
+  assert.ok(
+    /this\._activeTerminalSlot\s*===\s*focusSlot/.test(body),
+    'already-active owner must skip duplicate focus/activate work'
+  );
 });
 
 check('Select-mode control is injected into the pane header', () => {
@@ -92,12 +125,25 @@ check('while ON, an "options paused" strip is shown', () => {
 check('one-time copy hint mentions Shift and Select mode, gated once', () => {
   assert.ok(/cwm_copyhint_v1/.test(termSrc), 'expected the one-time localStorage gate');
   assert.ok(/Shift/.test(termSrc), 'expected the hint to mention Shift');
+  const start = termSrc.indexOf('  _maybeShowCopyHint() {');
+  const end = termSrc.indexOf('\n  /** Dismiss the one-time copy hint', start);
+  const body = start >= 0 && end > start ? termSrc.slice(start, end) : '';
+  assert.ok(/localStorage\.setItem\('cwm_copyhint_v1', '1'\)/.test(body),
+    'the hint must be marked shown immediately so a host rebind cannot repeat it');
 });
 
-check('Ctrl+C branch still copies the xterm selection (Shift path payoff)', () => {
-  // The always-on Shift+drag path is only useful if Ctrl+C reads the selection.
-  assert.ok(/shortcutKey === 'c'[\s\S]{0,160}hasSelection\(\)/.test(termSrc),
-    'expected the normalized Ctrl+C branch to gate on this.term.hasSelection()');
+check('Ctrl+C leaves selected text on the trusted native copy path', () => {
+  const start = termSrc.indexOf("if (mod && shortcutKey === 'c')");
+  const end = termSrc.indexOf('// Ctrl+V / Cmd+V', start);
+  const body = start >= 0 && end > start ? termSrc.slice(start, end) : '';
+  assert.ok(/getCopySelection\(\)/.test(body),
+    'expected normalized Ctrl+C to read the pane-scoped selection');
+  assert.ok(/copySelection\.hasSelection\)\s*return false/.test(body),
+    'selected Ctrl+C must be withheld from the PTY');
+  assert.ok(!/preventDefault/.test(body),
+    'selected Ctrl+C must not cancel Chromium/xterm native copy');
+  assert.ok(!/copyTextToClipboard/.test(body),
+    'keyboard copy must not use the permission-gated async helper');
 });
 
 check('dispose() tears the interceptor + injected DOM down', () => {
@@ -106,9 +152,14 @@ check('dispose() tears the interceptor + injected DOM down', () => {
   assert.ok(/this\._selectModeBtn\.remove\(\)/.test(termSrc), 'expected the toggle button removed');
 });
 
-check('index.html cache-buster on terminal.js was bumped to copymode3', () => {
-  assert.ok(/terminal\.js\?v=20260725-copymode3/.test(indexSrc),
-    'expected terminal.js?v=20260725-copymode3 in index.html');
+check('index.html cache-busts the native-copy terminal fix', () => {
+  assert.ok(/terminal\.js\?v=20260725-copy-native5/.test(indexSrc),
+    'expected the final terminal.js native-copy cache token');
+});
+
+check('index.html cache-busts the app pane-focus/host fix', () => {
+  assert.ok(/app\.js\?v=20260725-copy-native5/.test(indexSrc),
+    'expected the final app.js native-copy cache token');
 });
 
 // ── Executed proof: run the real interceptor ─────────────────
@@ -128,9 +179,12 @@ function loadTerminalPane() {
     navigator: {},
     MouseEvent: FakeMouseEvent,
     requestAnimationFrame: () => 0,
+    setTimeout: () => 1,
+    clearTimeout: (id) => recorder.clearedTimers.push(id),
     localStorage: { getItem: () => null, setItem: () => {} },
     console,
   };
+  recorder.clearedTimers = [];
   sandbox.window.matchMedia = () => ({ matches: false });
   vm.createContext(sandbox);
   vm.runInContext(termSrc, sandbox, { filename: 'terminal.js' });
@@ -143,24 +197,57 @@ function loadTerminalPane() {
  * @param {boolean} selectMode - initial _selectMode for the fake pane.
  * @param {Array} dispatched - array that fake dispatchEvent pushes into.
  * @param {boolean} [hasSelection=false] - Whether xterm has selected text.
- * @returns {{handler: Function, TerminalPane: Function, FakeMouseEvent: Function}}
+ * @returns {{handler: Function, handlers: Object, TerminalPane: Function, FakeMouseEvent: Function}}
  */
 function installOnFakeContainer(selectMode, dispatched, hasSelection = false) {
   const { TerminalPane, FakeMouseEvent, sandbox } = loadTerminalPane();
-  let handler = null;
+  const handlers = {};
   const container = {
-    addEventListener: (type, fn) => { if (type === 'mousedown') handler = fn; },
+    addEventListener: (type, fn) => { handlers[type] = fn; },
     removeEventListener: () => {},
     dispatchEvent: (e) => dispatched.push(e),
   };
   const ctx = { containerId: 'x', _selectMode: selectMode, _selectDragging: false,
     _selInterceptorContainer: null, _selMouseHandler: null,
-    term: { hasSelection: () => hasSelection } };
+    term: {
+      hasSelection: () => hasSelection,
+      getSelection: () => hasSelection ? 'SELECTED' : '',
+    },
+    getCopySelection: () => ({
+      hasSelection,
+      text: hasSelection ? 'SELECTED' : '',
+      source: hasSelection ? 'xterm' : null,
+    }),
+    _getOwnedContainer: () => container,
+  };
   // The interceptor resolves `document` to the SANDBOX document (it is a
   // closure defined inside the vm), so route the fake container through there.
   sandbox.document.getElementById = () => container;
   TerminalPane.prototype._installSelectModeInterceptor.call(ctx);
-  return { handler, TerminalPane, FakeMouseEvent };
+  return {
+    handler: handlers.mousedown,
+    handlers,
+    TerminalPane,
+    FakeMouseEvent,
+  };
+}
+
+/**
+ * Compile the production app focus helper in isolation. Its body only calls
+ * other instance methods/properties, so a small object stub can execute the
+ * real event-order logic without booting the Workbook SPA.
+ * @returns {Function} Production _focusTerminalPaneFromPointer method.
+ */
+function loadFocusHelper() {
+  const start = appSrc.indexOf('  _focusTerminalPaneFromPointer(slotIdx, event) {');
+  const end = appSrc.indexOf('\n  /**\n   * Set the active terminal pane', start);
+  assert.ok(start >= 0 && end > start, 'could not extract the production focus helper');
+  const methodSource = appSrc.slice(start, end).trim();
+  return vm.runInNewContext(
+    '({' + methodSource + '})._focusTerminalPaneFromPointer',
+    {},
+    { filename: 'app-focus-helper.js' }
+  );
 }
 
 check('executed: interceptor is a no-op while Select mode is OFF', () => {
@@ -239,6 +326,152 @@ check('executed: right-click on selected text cannot reach the mouse-reporting T
   assert.strictEqual(stopped, true, 'selected right-click must be stopped before xterm reports it');
   assert.strictEqual(prevented, false, 'contextmenu must remain available for the Copy action');
   assert.strictEqual(dispatched.length, 0, 'selected right-click must not synthesize a mouse event');
+});
+
+check('executed: selected hover and right-button release cannot reach the TUI', () => {
+  const dispatched = [];
+  const { handlers } = installOnFakeContainer(false, dispatched, true);
+  for (const event of [
+    { type: 'mousemove', button: 0, buttons: 0 },
+    { type: 'mouseup', button: 2, buttons: 0 },
+  ]) {
+    let stopped = false;
+    let prevented = false;
+    handlers[event.type]({
+      ...event,
+      __cwmSelSynthetic: false,
+      cancelable: true,
+      target: { dispatchEvent: (e) => dispatched.push(e) },
+      preventDefault: () => { prevented = true; },
+      stopImmediatePropagation: () => { stopped = true; },
+    });
+    assert.strictEqual(stopped, true, event.type + ' must be stopped while text is selected');
+    assert.strictEqual(prevented, false, event.type + ' must preserve the later contextmenu default');
+  }
+  assert.strictEqual(dispatched.length, 0, 'selection-preservation guards must not synthesize input');
+});
+
+check('executed: a stale mobile selection reset cannot cross a host rebind', () => {
+  const { TerminalPane, recorder } = loadTerminalPane();
+  const ctx = {
+    _mobileSelectionResetTimer: 77,
+    _mobileSelecting: false,
+    _xtermScreen: { style: { pointerEvents: 'none' } },
+  };
+  TerminalPane.prototype._enableMobileSelection.call(ctx);
+  assert.deepStrictEqual(recorder.clearedTimers, [77]);
+  assert.strictEqual(ctx._mobileSelectionResetTimer, null);
+  assert.strictEqual(ctx._mobileSelecting, true);
+  assert.strictEqual(ctx._xtermScreen.style.pointerEvents, 'auto');
+});
+
+check('executed: active pane raw + synthetic drag start performs zero app activations', () => {
+  const focusHelper = loadFocusHelper();
+  const pane = {
+    getCopySelection: () => ({ hasSelection: false, text: '', source: null }),
+  };
+  let activations = 0;
+  const app = {
+    terminalPanes: [pane],
+    _activeTerminalSlot: 0,
+    _terminalPaneFromPointerEvent: () => pane,
+    setActiveTerminalPane(slot) {
+      activations++;
+      this._activeTerminalSlot = slot;
+    },
+  };
+  const terminalTarget = {
+    closest: (selector) => selector === '.xterm' ? {} : null,
+  };
+  const rawResult = focusHelper.call(app, 0, {
+    type: 'mousedown',
+    button: 0,
+    target: terminalTarget,
+  });
+  const cloneResult = focusHelper.call(app, 0, {
+    type: 'mousedown',
+    button: 0,
+    __cwmSelSynthetic: true,
+  });
+  assert.strictEqual(rawResult, false, 'active raw mousedown needs no app focus work');
+  assert.strictEqual(cloneResult, false, 'nested synthetic mousedown needs no app focus work');
+  assert.strictEqual(activations, 0, 'active selection start must never refocus/refit the pane');
+});
+
+check('executed: inactive pane raw + synthetic drag start activates exactly once', () => {
+  const focusHelper = loadFocusHelper();
+  const pane = {
+    getCopySelection: () => ({ hasSelection: false, text: '', source: null }),
+  };
+  let activations = 0;
+  const app = {
+    terminalPanes: [pane],
+    _activeTerminalSlot: null,
+    _terminalPaneFromPointerEvent: () => pane,
+    setActiveTerminalPane(slot) {
+      activations++;
+      this._activeTerminalSlot = slot;
+    },
+  };
+  assert.strictEqual(
+    focusHelper.call(app, 0, { type: 'mousedown', button: 0 }),
+    true,
+    'inactive raw mousedown must activate its owner'
+  );
+  assert.strictEqual(
+    focusHelper.call(app, 0, {
+      type: 'mousedown',
+      button: 0,
+      __cwmSelSynthetic: true,
+    }),
+    false,
+    'nested clone must see the owner as active'
+  );
+  assert.strictEqual(activations, 1, 'raw + nested clone must activate exactly once');
+});
+
+check('executed: active pane chrome click still refocuses the terminal', () => {
+  const focusHelper = loadFocusHelper();
+  const pane = {
+    getCopySelection: () => ({ hasSelection: false, text: '', source: null }),
+  };
+  let activations = 0;
+  const app = {
+    terminalPanes: [pane],
+    _activeTerminalSlot: 0,
+    _terminalPaneFromPointerEvent: () => pane,
+    setActiveTerminalPane() { activations++; },
+  };
+  const result = focusHelper.call(app, 0, {
+    type: 'mousedown',
+    button: 0,
+    target: { closest: () => null },
+  });
+  assert.strictEqual(result, true, 'pane chrome retains click-anywhere-to-focus behavior');
+  assert.strictEqual(activations, 1);
+});
+
+check('executed: selected right press stops before any app activation', () => {
+  const focusHelper = loadFocusHelper();
+  const pane = {
+    getCopySelection: () => ({ hasSelection: true, text: 'COPY ME', source: 'xterm' }),
+  };
+  let activations = 0;
+  let stopped = 0;
+  const app = {
+    terminalPanes: [pane],
+    _activeTerminalSlot: null,
+    _terminalPaneFromPointerEvent: () => pane,
+    setActiveTerminalPane() { activations++; },
+  };
+  const result = focusHelper.call(app, 0, {
+    type: 'mousedown',
+    button: 2,
+    stopPropagation() { stopped++; },
+  });
+  assert.strictEqual(result, false);
+  assert.strictEqual(stopped, 1, 'selected right press must stop at the pane capture boundary');
+  assert.strictEqual(activations, 0, 'selected right press must never focus/activate/refit');
 });
 
 console.log('\n  ' + passed + ' passed, ' + failed + ' failed');


### PR DESCRIPTION
## Summary

- make Select-mode drag, right-click Copy, and Ctrl+C dependable inside
  mouse-capturing terminal TUIs
- keep keyboard copy on Chromium/xterm's trusted event path while retaining
  insecure-origin and denied-Clipboard-API fallbacks for explicit Copy actions
- fence deferred mounts and asynchronous voice, upload, context-menu, fatal,
  provider, activity, and auto-trust work to the correct pane owner
- preserve terminal controls, mobile terminal/mirror selection, and mirror
  reading position across pane moves and tab-group caching
- remove unfinished pane-local structured views that duplicated the canonical
  Tasks workflow and created blank/ephemeral panes
- force browsers to fetch the corrected terminal, shell, and mirror assets

## Verification

- `npm test`
- `npm run test:browser`
  - real Chromium/xterm terminal fixture
  - complete isolated Workbook shell at desktop, tablet, mobile, light, and
    classic density
- copy fallback 20/20
- Select/right-click 22/22
- terminal host ownership 15/15
- mirror reading state 3/3
- mobile UX 26/26
- live GUI right-click Copy → Quick Switcher: exact `/compact`
- live GUI Ctrl+C → Quick Switcher: exact `/compact`
- live GUI Personal → Loussine → Personal lifecycle: pass
- JavaScript syntax and `git diff --check`
- package dry-run
- independent adversarial review: approve

## Release boundary

This prepares GitHub prerelease `v1.3.0-alpha.4`. It does not publish to npm,
deploy `workbook.myrlin.dev`, modify tunnels, stop unrelated processes, rewrite
the Windows scheduled task, or push the unsafe `origin` remote.
