### PR TITLE
Fix terminal copy after refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0-alpha.5] - 2026-07-27
+
+This corrective prerelease closes the remaining explicit terminal-copy failure found in the live embedded browser.
+
+### Fixed
+
+- **Right-click Copy no longer trusts a false-positive legacy result.** Some Chromium/WebView hosts return `true` from `document.execCommand('copy')` without changing the OS clipboard. Workbook still makes that synchronous attempt first for insecure LAN origins and denied-permission fallbacks, but a secure origin now invokes `navigator.clipboard.writeText` in the same trusted click even when the legacy command claims success. A legacy result is accepted only when its synchronous `copy` event handled the explicit payload; if both paths fail, the menu now reports failure instead of a false success.
+- **The insecure-origin fallback supplies and verifies its payload explicitly.** The temporary textarea handles the synchronous `copy` event, writes the exact plain-text value through `ClipboardEvent.clipboardData`, prevents the browser default, and records the handled event before cleanup. This keeps plain-HTTP remote access independent of the async Clipboard API without trusting an advisory command result.
+- **Terminal focus and selection survive menu Copy immediately.** The menu starts both clipboard attempts while the trusted click is live, then synchronously refocuses the exact pane and restores the public xterm range if focus cleared it. Ctrl+C therefore works even while a permission prompt is pending, and later promise settlement cannot overwrite a newer selection.
+- **Select mode survives refresh for the same terminal.** Workbook remembers an explicit Select-mode choice per session, so refreshing the authenticated public app no longer silently turns ordinary drag-to-select back into TUI mouse input. Other panes remain in clickable mode unless the user enables selection there.
+- **Fresh browsers receive the repair.** Terminal, shell, and mirror scripts use a new cache token.
+
+### Testing
+
+- Added VM coverage for a truthy no-op `execCommand`, the dual-failure cross-product with a denied modern write, insecure origins, exact fallback payloads, truthful toasts, and synchronous focus restoration.
+- Added real Chromium coverage in both the terminal interaction fixture and the complete Workbook shell. The terminal fixture now enables Select mode, reloads the page, and proves plain drag plus exact Ctrl+C still work. The shell test drives production xterm and the production context-menu renderer, seeds a clipboard sentinel, delays and counts the modern write, verifies no early toast, checks scratch-textarea cleanup, presses Ctrl+C while the write is still pending, and proves promise settlement preserves a newer selection.
+
 ## [1.3.0-alpha.4] - 2026-07-25
 
 This corrective prerelease closes the live terminal copy regression that remained after alpha.3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myrlin-workbook",
-  "version": "1.3.0-alpha.4",
+  "version": "1.3.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myrlin-workbook",
-      "version": "1.3.0-alpha.4",
+      "version": "1.3.0-alpha.5",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myrlin-workbook",
-  "version": "1.3.0-alpha.4",
+  "version": "1.3.0-alpha.5",
   "description": "Browser-based project manager for AI coding assistants (Claude Code, ChatGPT Codex). Multi-provider session discovery, search, live terminals, docs, kanban, themes.",
   "main": "src/index.js",
   "bin": {

--- a/src/web/public/app.js
+++ b/src/web/public/app.js
@@ -12288,9 +12288,18 @@ class CWMApp {
         typeof TerminalPane.copyTextToClipboard === 'function')
       ? TerminalPane.copyTextToClipboard(text)
       : Promise.resolve(false);
-    copied.then((ok) => {
+    // Return the settled result so actions that own a focus target (notably a
+    // terminal context menu) can keep the clipboard attempt and their immediate
+    // focus restoration in the same click flow. Normalize an unexpected
+    // rejection as a truthful failure even though TerminalPane's helper itself
+    // promises never to reject.
+    return Promise.resolve(copied).then((ok) => {
       if (ok) this.showToast(successMessage, 'success');
       else this.showToast(failureMessage || 'Copy failed', 'error');
+      return !!ok;
+    }, () => {
+      this.showToast(failureMessage || 'Copy failed', 'error');
+      return false;
     });
   }
 
@@ -16259,6 +16268,22 @@ class CWMApp {
               source: 'xterm',
             });
     const selectedText = selection.hasSelection ? String(selection.text) : '';
+    // xterm may clear its model selection when keyboard focus returns from a
+    // floating menu. Keep a public-API position snapshot so Copy can restore
+    // the exact range for a retry (including a follow-up Ctrl+C).
+    let xtermSelectionPosition = null;
+    if (selection.hasSelection && selection.source === 'xterm' && tp.term &&
+        typeof tp.term.getSelectionPosition === 'function') {
+      try {
+        const position = tp.term.getSelectionPosition();
+        if (position && position.start && position.end) {
+          xtermSelectionPosition = {
+            start: { x: position.start.x, y: position.start.y },
+            end: { x: position.end.x, y: position.end.y },
+          };
+        }
+      } catch (_) {}
+    }
 
     // ── Terminal-specific actions ──────────────────────────────
 
@@ -16266,7 +16291,32 @@ class CWMApp {
     if (selection.hasSelection) {
       items.push({
         label: 'Copy', icon: '&#128203;', action: () => {
-          this._copyWithToast(selectedText, 'Copied to clipboard');
+          // Start both clipboard paths while the trusted menu click is live.
+          // Then restore focus/selection synchronously: a slow permission prompt
+          // must not leave Ctrl+C stranded on <body>, and a later promise
+          // settlement must never overwrite a newer user selection.
+          const copyPromise = this._copyWithToast(selectedText, 'Copied to clipboard');
+          if (resolveLiveOwnerSlot() >= 0 && typeof tp.focus === 'function') {
+            tp.focus();
+            if (xtermSelectionPosition && tp.term &&
+                typeof tp.term.select === 'function' &&
+                typeof tp.term.getSelection === 'function' &&
+                tp.term.getSelection() !== selectedText) {
+              const start = xtermSelectionPosition.start;
+              const end = xtermSelectionPosition.end;
+              const length = ((end.y - start.y) * tp.term.cols) - start.x + end.x;
+              if (length > 0) {
+                tp.term.select(start.x, start.y, length);
+                // Never leave a silently shifted range selected if the TUI
+                // repainted between contextmenu and the menu click.
+                if (tp.term.getSelection() !== selectedText &&
+                    typeof tp.term.clearSelection === 'function') {
+                  tp.term.clearSelection();
+                }
+              }
+            }
+          }
+          return copyPromise;
         },
       });
     }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -1989,13 +1989,13 @@
        server-side /api/providers metadata onto these locals to build the
        runtime map window.CWMProviderSpecs. -->
   <script src="provider-specs.js"></script>
-  <script src="terminal.js?v=20260725-copy-native5"></script>
+  <script src="terminal.js?v=20260727-copy-native8"></script>
   <script src="instance-colors.js"></script>
   <!-- Issue #10 Tier 1 Phase 4: MirrorPaneView (read-only session mirror).
        MUST load before app.js so window.MirrorPaneView exists when
        _renderMirrorInPane mounts a mirror pane. -->
-  <script src="mirror-view.js?v=20260725-copy-native5"></script>
-  <script src="app.js?v=20260725-copy-native5"></script>
+  <script src="mirror-view.js?v=20260727-copy-native8"></script>
+  <script src="app.js?v=20260727-copy-native8"></script>
   <script src="schedules.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/src/web/public/terminal.js
+++ b/src/web/public/terminal.js
@@ -474,11 +474,18 @@ class TerminalPane {
    *
    * Gesture ordering matters: an embedded browser may expose writeText but
    * reject it only after the trusted click has expired. Explicit copy actions
-   * therefore try the synchronous execCommand path FIRST, while user
-   * activation is unquestionably live, then use writeText when that path is
-   * unavailable (for example, an async action outside a click). The function
-   * check remains required because some engines expose a clipboard object
-   * without writeText.
+   * therefore make the synchronous execCommand attempt FIRST, while user
+   * activation is unquestionably live, then invoke writeText immediately in
+   * the SAME call stack whenever it exists.
+   *
+   * Both attempts are intentional. Chromium/WebView can return true from
+   * execCommand('copy') even though the OS clipboard was not changed. That
+   * boolean means the command was accepted, not that a clipboard commit can be
+   * verified, so it must never short-circuit the modern API. Conversely, the
+   * synchronous attempt remains the only viable path on insecure LAN origins
+   * and can rescue embedded browsers that expose but deny writeText. The
+   * function check remains required because some engines expose a clipboard
+   * object without writeText.
    *
    * Contract: NEVER throws and the returned promise NEVER rejects, under any
    * circumstance, so callers inside click handlers stay exception-safe.
@@ -493,27 +500,41 @@ class TerminalPane {
       // Preserve the trusted user gesture. If this helper was entered from a
       // menu/button click, execCommand(copy) runs synchronously in that same
       // stack and cannot lose activation while an async permission check is
-      // settling. When the helper is called outside a gesture it simply
-      // reports false and the modern Clipboard API remains available below.
+      // settling. Do not treat its return value as proof of an OS clipboard
+      // write: embedded Chromium has been observed returning true for a no-op.
+      let legacyVerified = false;
       try {
-        if (TerminalPane._copyViaExecCommand(value)) {
-          return Promise.resolve(true);
-        }
+        legacyVerified = TerminalPane._copyViaExecCommand(value);
       } catch (_) {}
 
       if (typeof navigator !== 'undefined' && navigator.clipboard &&
           typeof navigator.clipboard.writeText === 'function') {
-        // Modern async fallback. Map BOTH outcomes so the promise can never
-        // reject. A second execCommand attempt on rejection is harmless and
-        // can still help engines that retain activation for the microtask.
-        return navigator.clipboard.writeText(value).then(
+        // Invoke this before yielding/awaiting so the click activation is still
+        // live. A resolved writeText is the authoritative secure-origin result.
+        // Map BOTH outcomes so the promise returned to callers never rejects.
+        let modernWrite;
+        try {
+          modernWrite = navigator.clipboard.writeText(value);
+        } catch (_) {
+          // Some implementations throw synchronously instead of returning a
+          // rejected promise. Preserve any already-completed legacy copy, or
+          // retry that path once if the first attempt was unavailable.
+          if (legacyVerified) return Promise.resolve(true);
+          try {
+            return Promise.resolve(TerminalPane._copyViaExecCommand(value));
+          } catch (_) {
+            return Promise.resolve(false);
+          }
+        }
+        return Promise.resolve(modernWrite).then(
           () => true,
           () => {
+            if (legacyVerified) return true;
             try { return TerminalPane._copyViaExecCommand(value); } catch (_) { return false; }
           }
         );
       }
-      return Promise.resolve(false);
+      return Promise.resolve(legacyVerified);
     } catch (_) {
       // Belt and braces: callers never see a gesture-handler exception.
       return Promise.resolve(false);
@@ -538,7 +559,9 @@ class TerminalPane {
    * the docs panel) is selected.
    *
    * @param {string} value - Already-stringified text to copy.
-   * @returns {boolean} True when execCommand reported success. Never throws.
+   * @returns {boolean} True only when execCommand reported success AND its
+   *   synchronous copy event accepted the explicit clipboard payload. Never
+   *   throws.
    */
   static _copyViaExecCommand(value) {
     if (typeof document === 'undefined' || !document.body ||
@@ -567,6 +590,24 @@ class TerminalPane {
     ta.style.boxShadow = 'none';
     ta.style.background = 'transparent';
     ta.style.opacity = '0';
+    // Supplying the payload on the synchronous copy event is more reliable
+    // than trusting the textarea's default selection transfer in embedded
+    // browsers. The listener is scoped to the temporary element, and setting
+    // clipboardData is permitted during the trusted copy gesture even when the
+    // async Clipboard API is unavailable on an insecure origin.
+    let copyEventHandled = false;
+    if (typeof ta.addEventListener === 'function') {
+      ta.addEventListener('copy', (event) => {
+        try {
+          if (event.clipboardData &&
+              typeof event.clipboardData.setData === 'function') {
+            event.clipboardData.setData('text/plain', value);
+            event.preventDefault();
+            copyEventHandled = true;
+          }
+        } catch (_) {}
+      }, { once: true });
+    }
     let ok = false;
     try {
       document.body.appendChild(ta);
@@ -575,7 +616,12 @@ class TerminalPane {
       // iOS Safari ignores select() on some versions; the explicit range
       // makes the selection real there too.
       if (typeof ta.setSelectionRange === 'function') ta.setSelectionRange(0, value.length);
-      ok = !!document.execCommand('copy');
+      const commandAccepted = !!document.execCommand('copy');
+      // A truthy execCommand result only means the command was accepted. Some
+      // embedded Chromium hosts return true without dispatching `copy` or
+      // changing the platform clipboard. Require the synchronous event to
+      // confirm that our explicit payload was actually handled.
+      ok = commandAccepted && copyEventHandled;
     } catch (_) {
       ok = false;
     } finally {
@@ -610,11 +656,46 @@ class TerminalPane {
   // After a WebSocket (re)connect, mute idle detection for this long so the
   // server's scrollback replay burst cannot fire a "ready for input" toast.
   static REPLAY_SUPPRESS_MS = 3000;
+  // Select mode is intentionally per terminal session: enabling it should
+  // survive a browser refresh for that same session without disabling
+  // clickable TUI controls in every other pane.
+  static SELECT_MODE_STORAGE_PREFIX = 'cwm_terminal_select_mode_v1:';
   // Matches CSI escape sequences. Same pattern _detectActivity and
   // _analyzeForAutoTrust already use for ANSI stripping; hoisted to a named
   // constant so the re-arm gate shares it. Only used with .replace (safe
   // for a /g regex; lastIndex is not carried across replace calls).
   static ANSI_ESCAPE_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
+
+  static _selectModeStorageKey(sessionId) {
+    const id = (sessionId === null || sessionId === undefined)
+      ? ''
+      : String(sessionId).trim();
+    if (!id) return '';
+    try {
+      return TerminalPane.SELECT_MODE_STORAGE_PREFIX + encodeURIComponent(id);
+    } catch (_) {
+      return '';
+    }
+  }
+
+  static _loadSelectModePreference(sessionId) {
+    const key = TerminalPane._selectModeStorageKey(sessionId);
+    if (!key || typeof localStorage === 'undefined') return false;
+    try {
+      return localStorage.getItem(key) === '1';
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static _saveSelectModePreference(sessionId, on) {
+    const key = TerminalPane._selectModeStorageKey(sessionId);
+    if (!key || typeof localStorage === 'undefined') return;
+    try {
+      if (on) localStorage.setItem(key, '1');
+      else localStorage.removeItem(key);
+    } catch (_) {}
+  }
 
   constructor(containerId, sessionId, sessionName, spawnOpts) {
     this.containerId = containerId;
@@ -672,8 +753,9 @@ class TerminalPane {
     // returns event.shiftKey on non-Mac), so Shift+drag always selects. This flag
     // powers an opt-in per-pane "Select mode" that makes a PLAIN drag behave like
     // a Shift+drag, so the user can copy without the interactive layer being
-    // disabled globally. OFF by default so clickable TUI options keep working.
-    this._selectMode = false;
+    // disabled globally. It starts OFF unless this same session was explicitly
+    // enabled before a refresh, so unrelated panes keep clickable TUI options.
+    this._selectMode = TerminalPane._loadSelectModePreference(this.sessionId);
     // References to the injected copy-mode DOM + the capture-phase mouse
     // interceptor, so dispose() can tear everything down cleanly.
     this._selectModeBtn = null;
@@ -2464,6 +2546,7 @@ class TerminalPane {
    */
   setSelectMode(on) {
     this._selectMode = !!on;
+    TerminalPane._saveSelectModePreference(this.sessionId, this._selectMode);
     if (this._selectMode) this._dismissCopyHint();
     this._updateSelectModeUI();
     return this._selectMode;

--- a/test/browser/terminal-interaction.html
+++ b/test/browser/terminal-interaction.html
@@ -221,9 +221,13 @@
         button.className = 'fixture-menu-item';
         button.textContent = item.label;
         button.dataset.label = item.label;
-        button.addEventListener('click', async () => {
-          await item.action();
+        button.addEventListener('click', () => {
+          // Match the production _renderContextItems ordering exactly. The
+          // floating menu is hidden before the action runs, so clipboard tests
+          // exercise the same focus and transient-user-activation conditions
+          // as a real Workbook context-menu click.
           menu.hidden = true;
+          item.action();
         });
         menu.appendChild(button);
       }

--- a/test/browser/terminal-interaction.test.js
+++ b/test/browser/terminal-interaction.test.js
@@ -566,6 +566,126 @@ async function run() {
     );
     assert.strictEqual(await page.evaluate(() => navigator.clipboard.readText()), rightClickSelection);
 
+    // execCommand's truthy result is advisory, not proof that the platform
+    // clipboard changed. Reproduce the live embedded-browser failure by making
+    // execCommand report true without dispatching a copy event or touching the
+    // clipboard. The modern write must still run during the same click and
+    // replace the sentinel with the exact contextmenu-time snapshot.
+    await page.evaluate(() => window.fixture.pane.term.select(0, 1, 18));
+    const truthyNoopSelection = (await readSelection(page)).text;
+    assert.ok(truthyNoopSelection, 'truthy-no-op scenario must begin with a real xterm selection');
+    await resetState(page);
+    const truthyNoopSentinel =
+      'MYRLIN_TRUTHY_NOOP_SENTINEL_' + process.pid + '_' + Date.now();
+    await page.evaluate(async (sentinel) => {
+      const nativeClipboard = navigator.clipboard;
+      await nativeClipboard.writeText(sentinel);
+      window.__nativeClipboardForTruthyNoop = nativeClipboard;
+      window.__hadOwnExecCommandForTruthyNoop =
+        Object.prototype.hasOwnProperty.call(document, 'execCommand');
+      window.__nativeExecCommandForTruthyNoop = document.execCommand;
+      window.__modernClipboardWrites = [];
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          readText: () => nativeClipboard.readText(),
+          writeText: (value) => {
+            window.__modernClipboardWrites.push(String(value));
+            return nativeClipboard.writeText(value);
+          },
+        },
+      });
+      // The command claims success but is a deliberate no-op, matching the
+      // false-positive observed in the live Workbook host.
+      document.execCommand = () => true;
+    }, truthyNoopSentinel);
+    await openContextMenu(page);
+    await page.locator('#fixture-context-menu [data-label="Copy"]').click();
+    await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
+      window.__copyAttempts[0].result !== null);
+    assert.deepStrictEqual(
+      await page.evaluate(() => window.__copyAttempts),
+      [{ text: truthyNoopSelection, result: true }],
+      'truthy execCommand must not short-circuit the modern clipboard write'
+    );
+    assert.deepStrictEqual(
+      await page.evaluate(() => window.__modernClipboardWrites),
+      [truthyNoopSelection],
+      'modern writeText must receive the exact terminal selection once'
+    );
+    assert.strictEqual(
+      await page.evaluate(() => window.__nativeClipboardForTruthyNoop.readText()),
+      truthyNoopSelection,
+      'modern writeText must replace the sentinel after a truthy no-op execCommand'
+    );
+
+    // Cross the two failure modes: the legacy command claims success but
+    // dispatches no copy event, while the modern write is denied. Neither
+    // unverified attempt may produce a success toast or replace the sentinel.
+    await resetState(page);
+    const dualFailureSentinel =
+      'MYRLIN_DUAL_FAILURE_SENTINEL_' + process.pid + '_' + Date.now();
+    await page.evaluate(async (sentinel) => {
+      const nativeClipboard = window.__nativeClipboardForTruthyNoop;
+      await nativeClipboard.writeText(sentinel);
+      window.__dualFailureExecCalls = 0;
+      window.__dualFailureWriteCalls = 0;
+      document.execCommand = (command) => {
+        if (String(command).toLowerCase() === 'copy') {
+          window.__dualFailureExecCalls += 1;
+          return true;
+        }
+        return false;
+      };
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          readText: () => nativeClipboard.readText(),
+          writeText: () => {
+            window.__dualFailureWriteCalls += 1;
+            return Promise.reject(new Error('denied'));
+          },
+        },
+      });
+      window.fixture.pane.term.select(0, 1, 18);
+    }, dualFailureSentinel);
+    const dualFailureSelection = (await readSelection(page)).text;
+    assert.ok(dualFailureSelection, 'dual-failure scenario must retain a real selection');
+    await openContextMenu(page);
+    await page.locator('#fixture-context-menu [data-label="Copy"]').click();
+    await page.waitForFunction(() => window.__copyAttempts.length === 1 &&
+      window.__copyAttempts[0].result === false);
+    assert.deepStrictEqual(
+      await page.evaluate(() => window.__toast),
+      { message: 'Copy failed', level: 'error' },
+      'dual failure must report an honest error'
+    );
+    assert.strictEqual(
+      await page.evaluate(() => window.__nativeClipboardForTruthyNoop.readText()),
+      dualFailureSentinel,
+      'dual failure must leave the platform clipboard sentinel unchanged'
+    );
+    assert.strictEqual(await page.evaluate(() => window.__dualFailureWriteCalls), 1);
+    assert.strictEqual(
+      await page.evaluate(() => window.__dualFailureExecCalls),
+      2,
+      'modern denial may retry legacy once, but neither truthy no-op is verified'
+    );
+    await page.evaluate(() => {
+      if (window.__hadOwnExecCommandForTruthyNoop) {
+        document.execCommand = window.__nativeExecCommandForTruthyNoop;
+      } else {
+        delete document.execCommand;
+      }
+      delete navigator.clipboard;
+      delete window.__nativeClipboardForTruthyNoop;
+      delete window.__nativeExecCommandForTruthyNoop;
+      delete window.__hadOwnExecCommandForTruthyNoop;
+      delete window.__modernClipboardWrites;
+      delete window.__dualFailureExecCalls;
+      delete window.__dualFailureWriteCalls;
+    });
+
     // Embedded browsers may expose navigator.clipboard while denying its
     // programmatic write. Keyboard copy must not touch that API: Chromium's
     // trusted copy event and xterm's synchronous clipboardData path still
@@ -617,9 +737,9 @@ async function run() {
     assert.strictEqual(await page.evaluate(() => window.__toast), null,
       'successful native copy must not show a failure toast');
 
-    // The explicit right-click helper must preserve the trusted click by
-    // copying synchronously before the exposed-but-denied async API can expire
-    // user activation.
+    // The explicit right-click helper tries the synchronous path first, then
+    // invokes the modern API in the same trusted click. If the modern API is
+    // denied, the already-completed synchronous copy remains the fallback.
     await page.evaluate(() => {
       window.__copyAttempts.length = 0;
       window.__toast = null;
@@ -632,8 +752,8 @@ async function run() {
       await page.evaluate(() => window.__toast),
       { message: 'Copied to clipboard', level: 'success' }
     );
-    assert.strictEqual(await page.evaluate(() => window.__clipboardWriteAttempts), 0,
-      'successful synchronous menu copy must not call the denied Clipboard API');
+    assert.strictEqual(await page.evaluate(() => window.__clipboardWriteAttempts), 1,
+      'menu copy must attempt the modern Clipboard API even when execCommand reports success');
     assert.strictEqual(
       await page.evaluate(() => window.__nativeClipboardForDenial.readText()),
       deniedKeyboardSelection,
@@ -944,10 +1064,51 @@ async function run() {
     const afterWheel = await page.evaluate(() => window.fixture.pane.term.buffer.active.viewportY);
     assert.ok(afterWheel < beforeWheel, 'normal-buffer wheel must move into scrollback');
 
+    // The repeated live failure happened specifically after refresh: the user
+    // had enabled Select mode, but a newly constructed TerminalPane silently
+    // reset it to OFF. Prove the real browser persists the mode for this exact
+    // terminal session and that plain-drag + Ctrl+C still work after reload.
+    const persistenceToggle = page.locator('.terminal-pane-selectmode');
+    await persistenceToggle.click();
+    assert.strictEqual(await persistenceToggle.getAttribute('aria-pressed'), 'true');
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForFunction(() =>
+      window.fixture && window.fixture.pane &&
+      window.fixture.pane.term && window.fixture.pane.term.element
+    );
+    await page.waitForFunction(() => {
+      const pane = window.fixture && window.fixture.pane;
+      const line = pane && pane.term && pane.term.buffer.active.getLine(1);
+      return !!(line && line.translateToString(true).includes('COPY_TARGET_ALPHA_BETA'));
+    });
+    const restoredToggle = page.locator('.terminal-pane-selectmode');
+    assert.strictEqual(
+      await restoredToggle.getAttribute('aria-pressed'),
+      'true',
+      'Select mode must remain ON for the same terminal after refresh'
+    );
+    await page.evaluate(() => window.fixture.pane.term.clearSelection());
+    await resetState(page);
+    await dragCopyTarget(page, false);
+    const refreshedSelection = (await readSelection(page)).text;
+    assert.ok(
+      refreshedSelection.includes('OPY_TARGET_ALPHA_BETA'),
+      'restored Select mode must make a plain drag select real terminal text'
+    );
+    await page.keyboard.press('Control+c');
+    await page.waitForFunction(() => window.__nativeCopyEvents.length === 1);
+    assert.strictEqual(
+      await page.evaluate(() => navigator.clipboard.readText()),
+      refreshedSelection,
+      'Ctrl+C after refresh must copy the exact restored-mode selection'
+    );
+    await restoredToggle.click();
+    assert.strictEqual(await restoredToggle.getAttribute('aria-pressed'), 'false');
+
     await page.screenshot({ path: SCREENSHOT_PATH, fullPage: true });
     console.log('PASS terminal browser acceptance');
     console.log('  Shift+drag: real selection, zero PTY mouse reports');
-    console.log('  Select mode: real selection + native Ctrl+C; mode off restores TUI mouse events');
+    console.log('  Select mode: persists across refresh; real selection + native Ctrl+C; mode off restores TUI mouse events');
     console.log('  Ctrl+C: trusted native copy; uppercase safety; denied API still works; no SIGINT');
     console.log('  Clipboard: native copy writes exact text under API denial; original formats restored');
     console.log('  Right-click: hover + both button edges preserve snapshot; truthful copy toast');

--- a/test/browser/workbook-shell.test.js
+++ b/test/browser/workbook-shell.test.js
@@ -22,6 +22,7 @@ const { chromium } = require('@playwright/test');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..');
 const SERVER_PATH = path.join(__dirname, 'workbook-shell-server.js');
+const CLIPBOARD_GUARD_PATH = path.join(__dirname, 'clipboard-guard.ps1');
 const SCREENSHOT_PATH = path.join(PROJECT_ROOT, 'screenshots', 'workbook-shell-e2e.png');
 const LIGHT_SCREENSHOT_PATH = path.join(PROJECT_ROOT, 'screenshots', 'workbook-shell-focused-light.png');
 const MOBILE_SCREENSHOT_PATH = path.join(PROJECT_ROOT, 'screenshots', 'workbook-shell-focused-mobile.png');
@@ -205,6 +206,90 @@ async function stopWorkbook(child) {
 }
 
 /**
+ * Snapshot every Windows clipboard format before the full-shell copy
+ * regression mutates it.
+ * @returns {Promise<import('child_process').ChildProcess>} Owned guard process.
+ */
+function startClipboardGuard() {
+  return new Promise((resolve, reject) => {
+    const child = spawn('powershell.exe', [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-STA',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      CLIPBOARD_GUARD_PATH,
+    ], {
+      cwd: PROJECT_ROOT,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    const timeout = setTimeout(async () => {
+      if (settled) return;
+      settled = true;
+      try { child.stdin.end(); } catch (_) {}
+      if (!(await waitForExit(child, 3000))) {
+        try { child.kill('SIGKILL'); } catch (_) {}
+        await waitForExit(child, 3000);
+      }
+      reject(new Error('clipboard guard did not become ready'));
+    }, 15000);
+
+    child.stdout.on('data', (chunk) => {
+      if (settled) return;
+      stdout += chunk.toString('utf8');
+      if (!stdout.includes('CLIPBOARD_GUARD_READY')) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(child);
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString('utf8');
+    });
+    child.once('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('exit', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(new Error('clipboard guard exited ' + code + ': ' + stderr.trim()));
+    });
+  });
+}
+
+/**
+ * Ask the clipboard guard to restore its complete snapshot and confirm exit.
+ * @param {import('child_process').ChildProcess} child - Owned guard process.
+ * @returns {Promise<void>}
+ */
+async function stopClipboardGuard(child) {
+  if (!child) return;
+  if (child.exitCode !== null || child.signalCode !== null) {
+    throw new Error('clipboard guard exited before restoration was requested');
+  }
+
+  const restored = waitForExit(child, 15000);
+  try { child.stdin.end('RESTORE\n'); } catch (_) {}
+  if (!(await restored)) {
+    try { child.kill('SIGKILL'); } catch (_) {}
+    await waitForExit(child, 3000);
+    throw new Error('clipboard guard did not confirm clipboard restoration');
+  }
+  if (child.exitCode !== 0) {
+    throw new Error('clipboard guard failed while restoring the clipboard');
+  }
+}
+
+/**
  * Delete only the validated temporary directory created by this test.
  * @param {string} sandbox - Candidate sandbox root.
  */
@@ -238,6 +323,7 @@ async function run() {
     const context = await browser.newContext({
       viewport: { width: 1440, height: 900 },
       colorScheme: 'dark',
+      permissions: ['clipboard-read', 'clipboard-write'],
     });
     const blockedExternalRequests = [];
     await context.route(/^https?:\/\//, (route) => {
@@ -277,8 +363,8 @@ async function run() {
     assert.strictEqual(shell.title, "myrlin's workbook");
     assert.strictEqual(shell.loginHidden, true, 'startup token must reveal the application shell');
     assert.strictEqual(shell.appHidden, false, 'application shell must be visible after startup auth');
-    assert.strictEqual(shell.terminalScript, 'terminal.js?v=20260725-copy-native5');
-    assert.strictEqual(shell.appScript, 'app.js?v=20260725-copy-native5');
+    assert.strictEqual(shell.terminalScript, 'terminal.js?v=20260727-copy-native8');
+    assert.strictEqual(shell.appScript, 'app.js?v=20260727-copy-native8');
     assert.strictEqual(shell.terminalClass, 'function', 'production TerminalPane must load');
     assert.strictEqual(shell.selectInterceptor, 'function', 'Select-mode interceptor must be present');
     assert.strictEqual(shell.themeRegistry, 'object', 'canonical theme registry must load before the app');
@@ -734,6 +820,483 @@ async function run() {
       'classic density query must survive reloads'
     );
     await classicPage.close();
+
+    // Exercise explicit terminal Copy through the complete Workbook shell:
+    // real xterm selection, production pane contextmenu capture, production
+    // #context-menu renderer, and the real menu-item click ordering. The
+    // isolated terminal never connects to a provider process.
+    //
+    // Chromium/WebView builds can report document.execCommand('copy') === true
+    // without changing the platform clipboard. That return value is therefore
+    // only a legacy attempt, not proof of success. Keep a working modern
+    // writeText path available and delay its promise so the assertions can
+    // prove the success toast waits for a real write.
+    const clipboardGuard = await startClipboardGuard();
+    let copyInstrumentationInstalled = false;
+    try {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      const copyMarker =
+        'FULL_SHELL_COPY_TARGET_' + process.pid + '_' + Date.now();
+      const copySentinel =
+        'FULL_SHELL_COPY_SENTINEL_' + process.pid + '_' + Date.now();
+
+      const copyGeometry = await page.evaluate(async (marker) => {
+        window.cwm.setViewMode('terminal');
+        if (window.cwm.els.toastContainer) {
+          window.cwm.els.toastContainer.replaceChildren();
+        }
+
+        const originalConnect = TerminalPane.prototype.connect;
+        TerminalPane.prototype.connect = function hermeticCopyConnect() {
+          this.connected = true;
+        };
+        try {
+          window.cwm.openTerminalInPane(
+            0,
+            'full-shell-copy-fixture',
+            'Copy regression',
+            { provider: 'claude' }
+          );
+          await new Promise((resolve, reject) => {
+            const deadline = Date.now() + 5000;
+            const poll = () => {
+              const pane = window.cwm.terminalPanes[0];
+              // mount() opens xterm before its double-rAF invokes connect().
+              // Keep the prototype stub installed until that deferred call has
+              // actually run; restoring it at element creation would let the
+              // fixture connect to the shell server and wipe the test buffer.
+              if (pane && pane.term && pane.term.element && pane.connected) {
+                resolve();
+                return;
+              }
+              if (Date.now() >= deadline) {
+                reject(new Error('hermetic terminal did not mount'));
+                return;
+              }
+              requestAnimationFrame(poll);
+            };
+            poll();
+          });
+        } finally {
+          TerminalPane.prototype.connect = originalConnect;
+        }
+
+        const pane = window.cwm.terminalPanes[0];
+        window.__fullShellCopyPane = pane;
+        await new Promise((resolve) => pane.term.write('\r\n' + marker, resolve));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        const buffer = pane.term.buffer.active;
+        let row = -1;
+        let column = -1;
+        const lastRow = buffer.baseY + pane.term.rows;
+        for (let index = 0; index < lastRow; index++) {
+          const line = buffer.getLine(index);
+          const text = line ? line.translateToString(true) : '';
+          const markerColumn = text.indexOf(marker);
+          if (markerColumn !== -1) {
+            row = index;
+            column = markerColumn;
+            break;
+          }
+        }
+        if (row < 0 || column < 0) {
+          throw new Error('copy marker was not rendered into xterm');
+        }
+
+        pane.term.select(column, row, marker.length);
+        pane.focus();
+        const selection = pane.getCopySelection();
+        const screen = pane.term.element.querySelector('.xterm-screen');
+        const rect = screen.getBoundingClientRect();
+        const cellWidth = rect.width / pane.term.cols;
+        const cellHeight = rect.height / pane.term.rows;
+        return {
+          x: rect.left + cellWidth * (column + marker.length / 2),
+          y: rect.top + cellHeight * (row - buffer.viewportY + 0.5),
+          selection,
+          selectionPosition: pane.term.getSelectionPosition(),
+          activeClass: document.activeElement && document.activeElement.className,
+          directBodyTextareas: document.querySelectorAll(':scope > body > textarea').length,
+        };
+      }, copyMarker);
+
+      assert.deepStrictEqual(
+        {
+          hasSelection: copyGeometry.selection.hasSelection,
+          text: copyGeometry.selection.text,
+          source: copyGeometry.selection.source,
+        },
+        { hasSelection: true, text: copyMarker, source: 'xterm' },
+        'full-shell copy regression must begin with the exact highlighted xterm text'
+      );
+      assert.strictEqual(
+        copyGeometry.activeClass,
+        'xterm-helper-textarea',
+        'the highlighted terminal must own keyboard focus before right-click'
+      );
+
+      await page.evaluate(async ({ marker, sentinel }) => {
+        const nativeClipboard = navigator.clipboard;
+        await nativeClipboard.writeText(sentinel);
+        const state = {
+          marker,
+          sentinel,
+          nativeClipboard,
+          navigatorClipboardDescriptor:
+            Object.getOwnPropertyDescriptor(navigator, 'clipboard') || null,
+          documentExecDescriptor:
+            Object.getOwnPropertyDescriptor(document, 'execCommand') || null,
+          nativeExecCommand: document.execCommand,
+          execCalls: [],
+          writeCalls: [],
+          nativeWriteSettled: false,
+          releaseWrite: null,
+          released: false,
+          copyEvents: [],
+        };
+        state.copyListener = (event) => {
+          state.copyEvents.push({
+            trusted: event.isTrusted,
+            targetTag: event.target && event.target.tagName,
+            defaultPrevented: event.defaultPrevented,
+          });
+        };
+        document.addEventListener('copy', state.copyListener, true);
+
+        document.execCommand = function truthyNoOpExecCommand(command) {
+          if (String(command).toLowerCase() !== 'copy') {
+            return state.nativeExecCommand.apply(document, arguments);
+          }
+          const active = document.activeElement;
+          state.execCalls.push({
+            activeTag: active && active.tagName,
+            value: active && typeof active.value === 'string' ? active.value : null,
+            selectionStart:
+              active && typeof active.selectionStart === 'number'
+                ? active.selectionStart
+                : null,
+            selectionEnd:
+              active && typeof active.selectionEnd === 'number'
+                ? active.selectionEnd
+                : null,
+            directBodyTextareas:
+              document.querySelectorAll(':scope > body > textarea').length,
+          });
+          // Deliberately return true without dispatching a copy event or
+          // changing the platform clipboard.
+          return true;
+        };
+
+        Object.defineProperty(navigator, 'clipboard', {
+          configurable: true,
+          value: {
+            readText: nativeClipboard.readText.bind(nativeClipboard),
+            writeText(value) {
+              const text = String(value);
+              state.writeCalls.push(text);
+              return nativeClipboard.writeText(text).then(() => {
+                state.nativeWriteSettled = true;
+                return new Promise((resolve) => {
+                  state.releaseWrite = () => {
+                    state.released = true;
+                    resolve();
+                  };
+                });
+              });
+            },
+          },
+        });
+        window.__fullShellCopyQa = state;
+      }, { marker: copyMarker, sentinel: copySentinel });
+      copyInstrumentationInstalled = true;
+
+      assert.strictEqual(
+        await page.evaluate(() =>
+          window.__fullShellCopyQa.nativeClipboard.readText()
+        ),
+        copySentinel,
+        'copy regression must seed a distinct clipboard sentinel'
+      );
+
+      await page.mouse.click(copyGeometry.x, copyGeometry.y, { button: 'right' });
+      const productionContextMenu = page.locator('#context-menu');
+      await productionContextMenu.waitFor({ state: 'visible' });
+      const productionCopyItem =
+        page.locator('#context-menu-items [data-action="Copy"]');
+      assert.strictEqual(
+        await productionCopyItem.count(),
+        1,
+        'production terminal context menu must expose Copy for highlighted text'
+      );
+      await productionCopyItem.click();
+
+      await page.waitForFunction(() => {
+        const state = window.__fullShellCopyQa;
+        return state && state.execCalls.length === 1 &&
+          state.writeCalls.length === 1 &&
+          state.nativeWriteSettled &&
+          typeof state.releaseWrite === 'function';
+      }, null, { timeout: 5000 });
+
+      const pendingCopy = await page.evaluate(() => {
+        const state = window.__fullShellCopyQa;
+        return {
+          execCalls: state.execCalls,
+          writeCalls: state.writeCalls,
+          copyEvents: state.copyEvents,
+          released: state.released,
+          menuHidden: document.getElementById('context-menu').hidden,
+          successToasts: Array.from(
+            document.querySelectorAll('#toast-container .toast-success .toast-message')
+          ).map((element) => element.textContent.trim()),
+          errorToasts: Array.from(
+            document.querySelectorAll('#toast-container .toast-error .toast-message')
+          ).map((element) => element.textContent.trim()),
+          directBodyTextareas:
+            document.querySelectorAll(':scope > body > textarea').length,
+        };
+      });
+      assert.deepStrictEqual(
+        pendingCopy.execCalls,
+        [{
+          activeTag: 'TEXTAREA',
+          value: copyMarker,
+          selectionStart: 0,
+          selectionEnd: copyMarker.length,
+          directBodyTextareas: copyGeometry.directBodyTextareas + 1,
+        }],
+        'legacy attempt must select the exact scratch textarea payload once'
+      );
+      assert.deepStrictEqual(
+        pendingCopy.writeCalls,
+        [copyMarker],
+        'truthy legacy result must not suppress the authoritative modern write'
+      );
+      assert.deepStrictEqual(
+        pendingCopy.copyEvents,
+        [],
+        'truthy no-op execCommand must not manufacture a native copy event'
+      );
+      assert.strictEqual(
+        pendingCopy.released,
+        false,
+        'modern write must remain pending until the test releases it'
+      );
+      assert.strictEqual(
+        pendingCopy.menuHidden,
+        true,
+        'production renderer must close the menu after Copy is activated'
+      );
+      assert.deepStrictEqual(
+        pendingCopy.successToasts,
+        [],
+        'success toast must wait for the authoritative clipboard write'
+      );
+      assert.deepStrictEqual(
+        pendingCopy.errorToasts,
+        [],
+        'a pending clipboard write must not show a false failure'
+      );
+      assert.strictEqual(
+        pendingCopy.directBodyTextareas,
+        copyGeometry.directBodyTextareas,
+        'temporary copy textarea must be removed before the async write settles'
+      );
+
+      // Focus and the contextmenu-time selection must be restored immediately,
+      // not after a slow Clipboard API promise. Otherwise Ctrl+C is stranded on
+      // <body> for the entire permission prompt.
+      const pendingOwner = await page.evaluate(() => {
+        const pane = window.__fullShellCopyPane;
+        return {
+          activeClass: document.activeElement && document.activeElement.className,
+          selection: pane.getCopySelection(),
+        };
+      });
+      assert.strictEqual(
+        pendingOwner.activeClass,
+        'xterm-helper-textarea',
+        'Copy must return focus to xterm before the modern write settles'
+      );
+      assert.strictEqual(
+        pendingOwner.selection.text,
+        copyMarker,
+        'Copy must restore the exact selection before the modern write settles'
+      );
+
+      const pendingCtrlCSentinel =
+        'FULL_SHELL_PENDING_CTRL_C_' + process.pid + '_' + Date.now();
+      await page.evaluate(
+        ({ sentinel }) =>
+          window.__fullShellCopyQa.nativeClipboard.writeText(sentinel),
+        { sentinel: pendingCtrlCSentinel }
+      );
+      await page.keyboard.press('Control+c');
+      await page.waitForFunction(async (marker) => (
+        await window.__fullShellCopyQa.nativeClipboard.readText()
+      ) === marker, copyMarker);
+      assert.deepStrictEqual(
+        await page.evaluate(async () => ({
+          clipboard: await window.__fullShellCopyQa.nativeClipboard.readText(),
+          selection: window.__fullShellCopyPane.getCopySelection().text,
+          modernWriteCalls: window.__fullShellCopyQa.writeCalls.slice(),
+        })),
+        {
+          clipboard: copyMarker,
+          selection: copyMarker,
+          modernWriteCalls: [copyMarker],
+        },
+        'Ctrl+C must work immediately while the explicit write promise is still pending'
+      );
+
+      // A user can create another selection while a permission prompt is open.
+      // Promise settlement must not restore the stale contextmenu snapshot over
+      // that newer selection.
+      const newerSelection = await page.evaluate((marker) => {
+        const pane = window.__fullShellCopyPane;
+        const position = pane.term.getSelectionPosition();
+        const length = Math.max(1, Math.floor(marker.length / 2));
+        pane.term.select(position.start.x, position.start.y, length);
+        return pane.getCopySelection().text;
+      }, copyMarker);
+      assert.ok(
+        newerSelection && newerSelection !== copyMarker,
+        'the pending-write race must install a distinct newer selection'
+      );
+
+      await page.evaluate(() => window.__fullShellCopyQa.releaseWrite());
+      await page.waitForFunction(() => (
+        Array.from(
+          document.querySelectorAll('#toast-container .toast-success .toast-message')
+        ).some((element) => element.textContent.trim() === 'Copied to clipboard')
+      ));
+
+      const completedCopy = await page.evaluate(async () => {
+        const pane = window.__fullShellCopyPane;
+        return {
+          clipboard: await window.__fullShellCopyQa.nativeClipboard.readText(),
+          successToasts: Array.from(
+            document.querySelectorAll('#toast-container .toast-success .toast-message')
+          ).map((element) => element.textContent.trim()),
+          errorToasts: Array.from(
+            document.querySelectorAll('#toast-container .toast-error .toast-message')
+          ).map((element) => element.textContent.trim()),
+          menuHidden: document.getElementById('context-menu').hidden,
+          activeClass: document.activeElement && document.activeElement.className,
+          selection: pane.getCopySelection(),
+          selectionPosition: pane.term.getSelectionPosition(),
+          directBodyTextareas:
+            document.querySelectorAll(':scope > body > textarea').length,
+        };
+      });
+      assert.strictEqual(
+        completedCopy.clipboard,
+        copyMarker,
+        'production right-click Copy must replace the sentinel with exact text'
+      );
+      assert.deepStrictEqual(
+        completedCopy.successToasts,
+        ['Copied to clipboard'],
+        'successful copy must produce exactly one truthful success toast'
+      );
+      assert.deepStrictEqual(
+        completedCopy.errorToasts,
+        [],
+        'successful copy must not also report a failure'
+      );
+      assert.strictEqual(completedCopy.menuHidden, true);
+      assert.strictEqual(
+        completedCopy.activeClass,
+        'xterm-helper-textarea',
+        'Copy must return focus to the owning terminal'
+      );
+      assert.strictEqual(
+        completedCopy.selection.text,
+        newerSelection,
+        'clipboard settlement must preserve the newer highlighted text: ' +
+          JSON.stringify({
+            initial: copyGeometry.selectionPosition,
+            completed: completedCopy.selectionPosition,
+          })
+      );
+      assert.strictEqual(
+        completedCopy.directBodyTextareas,
+        copyGeometry.directBodyTextareas,
+        'completed copy must leave no scratch textarea behind'
+      );
+
+      // The context-menu button must not strand focus on <body>. Seed another
+      // sentinel, press the real keyboard shortcut without re-focusing xterm,
+      // and prove the retained selection uses Chromium's trusted native copy
+      // path rather than calling the explicit helper a second time.
+      const postMenuCtrlCSentinel =
+        'FULL_SHELL_POST_MENU_CTRL_C_' + process.pid + '_' + Date.now();
+      await page.evaluate(
+        ({ sentinel }) =>
+          window.__fullShellCopyQa.nativeClipboard.writeText(sentinel),
+        { sentinel: postMenuCtrlCSentinel }
+      );
+      await page.keyboard.press('Control+c');
+      await page.waitForFunction(async (marker) => (
+        await window.__fullShellCopyQa.nativeClipboard.readText()
+      ) === marker, newerSelection);
+      const postMenuCtrlC = await page.evaluate(async () => {
+        const pane = window.cwm.terminalPanes[0];
+        return {
+          clipboard: await window.__fullShellCopyQa.nativeClipboard.readText(),
+          selection: pane.getCopySelection(),
+          modernWriteCalls: window.__fullShellCopyQa.writeCalls.slice(),
+        };
+      });
+      assert.strictEqual(
+        postMenuCtrlC.clipboard,
+        newerSelection,
+        'Ctrl+C after settlement must copy the newer retained selection'
+      );
+      assert.strictEqual(
+        postMenuCtrlC.selection.text,
+        newerSelection,
+        'native Ctrl+C must leave the xterm selection visible'
+      );
+      assert.deepStrictEqual(
+        postMenuCtrlC.modernWriteCalls,
+        [copyMarker],
+        'keyboard Ctrl+C must not re-enter the explicit async clipboard helper'
+      );
+    } finally {
+      try {
+        if (copyInstrumentationInstalled) {
+          await page.evaluate(() => {
+            const state = window.__fullShellCopyQa;
+            if (!state) return;
+            document.removeEventListener('copy', state.copyListener, true);
+            if (state.documentExecDescriptor) {
+              Object.defineProperty(
+                document,
+                'execCommand',
+                state.documentExecDescriptor
+              );
+            } else {
+              delete document.execCommand;
+            }
+            if (state.navigatorClipboardDescriptor) {
+              Object.defineProperty(
+                navigator,
+                'clipboard',
+                state.navigatorClipboardDescriptor
+              );
+            } else {
+              delete navigator.clipboard;
+            }
+            delete window.__fullShellCopyQa;
+            delete window.__fullShellCopyPane;
+          });
+        }
+      } finally {
+        await stopClipboardGuard(clipboardGuard);
+      }
+    }
 
     assert.deepStrictEqual(pageErrors, [], 'full Workbook page raised browser errors');
     const unexpectedExternalRequests = blockedExternalRequests.filter((requestUrl) => (

--- a/test/copy-secure-context-fallback.test.js
+++ b/test/copy-secure-context-fallback.test.js
@@ -114,11 +114,19 @@ function loadTerminalPane() {
  * creation, body append/remove bookkeeping, selection stubs, and an
  * execCommand that records what text was selected in the scratch textarea
  * at copy time (the observable "clipboard").
- * @param {Object} [opts] - { execThrows, execFails } failure injection.
+ * @param {Object} [opts] - { execThrows, execFails, execResults,
+ *   noCopyEvent } failure injection.
  * @returns {{doc: Object, record: Object}} The stub and its call record.
  */
 function makeStubDocument(opts) {
-  const record = { execCalls: [], copiedValues: [], appended: [], removed: [] };
+  const record = {
+    execCalls: [],
+    copiedValues: [],
+    clipboardPayloads: [],
+    copyEvents: [],
+    appended: [],
+    removed: [],
+  };
   const body = {
     children: [],
     appendChild(el) { el.parentNode = body; body.children.push(el); record.appended.push(el); },
@@ -134,6 +142,7 @@ function makeStubDocument(opts) {
     body,
     activeElement: body,
     createElement(tag) {
+      const listeners = new Map();
       return {
         tagName: tag,
         value: '',
@@ -143,6 +152,16 @@ function makeStubDocument(opts) {
         focus() {},
         select() {},
         setSelectionRange() {},
+        addEventListener(type, listener, options) {
+          const entries = listeners.get(type) || [];
+          entries.push({ listener, once: !!(options && options.once) });
+          listeners.set(type, entries);
+        },
+        __dispatch(type, event) {
+          const entries = (listeners.get(type) || []).slice();
+          for (const entry of entries) entry.listener(event);
+          listeners.set(type, entries.filter((entry) => !entry.once));
+        },
       };
     },
     getSelection() { return { rangeCount: 0, removeAllRanges() {}, addRange() {} }; },
@@ -151,10 +170,27 @@ function makeStubDocument(opts) {
       if (opts && opts.execThrows) throw new Error('execCommand blocked');
       const ta = body.children[body.children.length - 1];
       record.copiedValues.push(ta ? ta.value : null);
+      let result = !(opts && opts.execFails);
       if (opts && Array.isArray(opts.execResults) && opts.execResults.length > 0) {
-        return opts.execResults.shift();
+        result = opts.execResults.shift();
       }
-      return !(opts && opts.execFails);
+      if (!(opts && opts.noCopyEvent) && ta &&
+          typeof ta.__dispatch === 'function') {
+        const event = {
+          defaultPrevented: false,
+          clipboardData: {
+            setData(type, value) {
+              record.clipboardPayloads.push({ type, value });
+            },
+          },
+          preventDefault() {
+            this.defaultPrevented = true;
+          },
+        };
+        ta.__dispatch('copy', event);
+        record.copyEvents.push({ defaultPrevented: event.defaultPrevented });
+      }
+      return result;
     },
   };
   return { doc, record };
@@ -252,6 +288,10 @@ async function main() {
       body.indexOf('_copyViaExecCommand') < body.indexOf('navigator.clipboard.writeText'),
       'gesture-preserving execCommand copy must run before awaiting the Clipboard API'
     );
+    assert.ok(
+      !/if\s*\(\s*TerminalPane\._copyViaExecCommand\(value\)\s*\)\s*\{\s*return\s+Promise\.resolve\(true\)/.test(body),
+      'truthy execCommand must not return early and suppress the authoritative modern write'
+    );
   });
 
   await check('_copyViaExecCommand uses execCommand(copy) with cleanup in a finally', () => {
@@ -266,6 +306,12 @@ async function main() {
       /removeChild/.test(finallyRegion),
       'the scratch textarea must be removed inside the finally so failed copies never leak DOM nodes'
     );
+    assert.ok(/clipboardData\.setData\('text\/plain', value\)/.test(body),
+      'the legacy copy event must explicitly provide the exact plain-text payload');
+    assert.ok(/event\.preventDefault\(\)/.test(body),
+      'the explicit legacy clipboard payload must replace the browser default');
+    assert.ok(/commandAccepted\s*&&\s*copyEventHandled/.test(body),
+      'a truthy command without a handled copy event must not claim success');
   });
 
   // -------------------------------------------------------------------------
@@ -284,10 +330,33 @@ async function main() {
   await check('app.js _copyWithToast wrapper exists and routes through the helper', () => {
     const idx = appSrc.indexOf('_copyWithToast(text, successMessage, failureMessage)');
     assert.ok(idx !== -1, '_copyWithToast method not found in app.js');
-    const body = appSrc.slice(idx, idx + 700);
+    const end = appSrc.indexOf('\n  showToast(', idx);
+    assert.ok(end > idx, '_copyWithToast method boundary not found');
+    const body = appSrc.slice(idx, end);
     assert.ok(/TerminalPane\.copyTextToClipboard/.test(body), '_copyWithToast must delegate to TerminalPane.copyTextToClipboard');
     assert.ok(/showToast\(successMessage, 'success'\)/.test(body), '_copyWithToast must keep the success toast');
     assert.ok(/'error'/.test(body), '_copyWithToast must toast failures');
+    assert.ok(/return Promise\.resolve\(copied\)\.then/.test(body),
+      '_copyWithToast must return its settled promise so terminal actions can restore focus');
+  });
+
+  await check('terminal context-menu Copy restores the selected pane before the async write settles', () => {
+    const start = appSrc.indexOf("label: 'Copy', icon: '&#128203;'");
+    assert.ok(start !== -1, 'terminal Copy context item not found');
+    const end = appSrc.indexOf('// Save to Notes', start);
+    assert.ok(end > start, 'terminal Copy context item boundary not found');
+    const body = appSrc.slice(start, end);
+    const copyStart = body.indexOf('const copyPromise = this._copyWithToast');
+    const focusStart = body.indexOf('tp.focus()');
+    const copyReturn = body.indexOf('return copyPromise');
+    assert.ok(copyStart !== -1 && focusStart > copyStart && copyReturn > focusStart,
+      'terminal Copy must start the async write, restore focus synchronously, then return the promise');
+    assert.ok(/resolveLiveOwnerSlot\(\)\s*>=\s*0/.test(body),
+      'focus restoration must verify that the selected pane is still live');
+    assert.ok(/tp\.focus\(\)/.test(body),
+      'terminal Copy must restore xterm focus so the next Ctrl+C reaches the selection');
+    assert.ok(/tp\.term\.select\(start\.x, start\.y, length\)/.test(body),
+      'terminal Copy must restore the public xterm range if focus clears the selection');
   });
 
   await check('mobile Copy prefers pane-scoped DOM/xterm selection before the full buffer', () => {
@@ -304,8 +373,8 @@ async function main() {
 
   await check('index.html cache-busts the changed native-copy scripts', () => {
     assert.ok(
-      /terminal\.js\?v=20260725-copy-native5/.test(indexSrc) &&
-        /app\.js\?v=20260725-copy-native5/.test(indexSrc),
+      /terminal\.js\?v=20260727-copy-native8/.test(indexSrc) &&
+        /app\.js\?v=20260727-copy-native8/.test(indexSrc),
       'native-copy and pane-event fixes must not reuse stale browser cache entries'
     );
   });
@@ -336,16 +405,73 @@ async function main() {
     assert.deepStrictEqual(record.execCalls, ['copy']);
   });
 
-  await check('helper: trusted click prefers synchronous copy before the async API', async () => {
+  await check('helper: trusted legacy copy remains a fallback when the modern write is denied', async () => {
     const { sandbox, TerminalPane } = loadTerminalPane();
     const written = [];
-    sandbox.navigator = { clipboard: { writeText(v) { written.push(v); return Promise.resolve(); } } };
+    sandbox.navigator = {
+      clipboard: {
+        writeText(v) {
+          written.push(v);
+          return Promise.reject(new Error('NotAllowedError'));
+        },
+      },
+    };
     const { doc, record } = makeStubDocument();
     sandbox.document = doc;
     const ok = await TerminalPane.copyTextToClipboard('secure path');
     assert.strictEqual(ok, true);
     assert.deepStrictEqual(record.copiedValues, ['secure path']);
-    assert.deepStrictEqual(written, [], 'successful synchronous copy must preserve the gesture and skip writeText');
+    assert.deepStrictEqual(
+      written,
+      ['secure path'],
+      'the modern API must still be attempted immediately even when execCommand reports true'
+    );
+  });
+
+  await check('helper: truthy execCommand cannot suppress a working modern clipboard write', async () => {
+    const { sandbox, TerminalPane } = loadTerminalPane();
+    const written = [];
+    sandbox.navigator = { clipboard: { writeText(v) { written.push(v); return Promise.resolve(); } } };
+    // Chromium/WebView can report true from execCommand(copy) without changing
+    // the OS clipboard. This is the exact live right-click regression: the
+    // boolean means the command was handled, not that the clipboard committed.
+    const { doc, record } = makeStubDocument();
+    sandbox.document = doc;
+    const ok = await TerminalPane.copyTextToClipboard('false-positive exec result');
+    assert.strictEqual(ok, true);
+    assert.deepStrictEqual(record.execCalls, ['copy'], 'the gesture-preserving attempt must still run first');
+    assert.deepStrictEqual(
+      written,
+      ['false-positive exec result'],
+      'a truthy legacy result must not skip the authoritative Clipboard API write'
+    );
+  });
+
+  await check('helper: truthy no-op exec plus denied modern write reports failure', async () => {
+    const { sandbox, TerminalPane } = loadTerminalPane();
+    sandbox.navigator = {
+      clipboard: {
+        writeText() {
+          return Promise.reject(new Error('NotAllowedError'));
+        },
+      },
+    };
+    const { doc, record } = makeStubDocument({ noCopyEvent: true });
+    sandbox.document = doc;
+    const ok = await TerminalPane.copyTextToClipboard('dual failure must stay truthful');
+    assert.strictEqual(
+      ok,
+      false,
+      'execCommand true without a copy event plus writeText denial is not a successful copy'
+    );
+    assert.deepStrictEqual(
+      record.execCalls,
+      ['copy', 'copy'],
+      'the denied modern result may retry legacy once, but neither no-op is verified'
+    );
+    assert.deepStrictEqual(record.copyEvents, []);
+    assert.deepStrictEqual(record.clipboardPayloads, []);
+    assert.strictEqual(doc.body.children.length, 0, 'both scratch textareas must be removed');
   });
 
   await check('helper: secure context uses writeText when synchronous copy is unavailable', async () => {

--- a/test/terminal-select-mode.test.js
+++ b/test/terminal-select-mode.test.js
@@ -59,8 +59,15 @@ function check(name, fn) {
 }
 
 // ── Source gates ─────────────────────────────────────────────
-check('terminal.js declares the _selectMode flag (OFF by default)', () => {
-  assert.ok(/this\._selectMode\s*=\s*false/.test(termSrc), 'expected this._selectMode = false');
+check('terminal.js restores Select mode per terminal session', () => {
+  assert.ok(/SELECT_MODE_STORAGE_PREFIX/.test(termSrc),
+    'expected a versioned per-session Select-mode storage key');
+  assert.ok(
+    /this\._selectMode\s*=\s*TerminalPane\._loadSelectModePreference\(this\.sessionId\)/.test(termSrc),
+    'constructor must restore the same terminal session preference after refresh'
+  );
+  assert.ok(/_saveSelectModePreference\(this\.sessionId,\s*this\._selectMode\)/.test(termSrc),
+    'setSelectMode must persist an explicit toggle');
 });
 
 check('setSelectMode + toggleSelectMode exist', () => {
@@ -153,12 +160,12 @@ check('dispose() tears the interceptor + injected DOM down', () => {
 });
 
 check('index.html cache-busts the native-copy terminal fix', () => {
-  assert.ok(/terminal\.js\?v=20260725-copy-native5/.test(indexSrc),
+  assert.ok(/terminal\.js\?v=20260727-copy-native8/.test(indexSrc),
     'expected the final terminal.js native-copy cache token');
 });
 
 check('index.html cache-busts the app pane-focus/host fix', () => {
-  assert.ok(/app\.js\?v=20260725-copy-native5/.test(indexSrc),
+  assert.ok(/app\.js\?v=20260727-copy-native8/.test(indexSrc),
     'expected the final app.js native-copy cache token');
 });
 
@@ -181,10 +188,15 @@ function loadTerminalPane() {
     requestAnimationFrame: () => 0,
     setTimeout: () => 1,
     clearTimeout: (id) => recorder.clearedTimers.push(id),
-    localStorage: { getItem: () => null, setItem: () => {} },
+    localStorage: {
+      getItem: (key) => recorder.storage.has(key) ? recorder.storage.get(key) : null,
+      setItem: (key, value) => recorder.storage.set(key, String(value)),
+      removeItem: (key) => recorder.storage.delete(key),
+    },
     console,
   };
   recorder.clearedTimers = [];
+  recorder.storage = new Map();
   sandbox.window.matchMedia = () => ({ matches: false });
   vm.createContext(sandbox);
   vm.runInContext(termSrc, sandbox, { filename: 'terminal.js' });
@@ -231,6 +243,35 @@ function installOnFakeContainer(selectMode, dispatched, hasSelection = false) {
     FakeMouseEvent,
   };
 }
+
+check('executed: Select mode survives refresh only for the same session', () => {
+  const { TerminalPane, recorder } = loadTerminalPane();
+  const first = new TerminalPane('x', 'session/a', 'Session A');
+  assert.strictEqual(first._selectMode, false, 'unseen sessions must keep clickable TUI mode');
+  first.setSelectMode(true);
+  assert.strictEqual(
+    recorder.storage.get('cwm_terminal_select_mode_v1:session%2Fa'),
+    '1',
+    'enabling Select mode must persist the encoded session key'
+  );
+
+  const restored = new TerminalPane('x', 'session/a', 'Session A');
+  const unrelated = new TerminalPane('y', 'session/b', 'Session B');
+  assert.strictEqual(restored._selectMode, true, 'same session must restore Select mode');
+  assert.strictEqual(unrelated._selectMode, false, 'other panes must retain clickable TUI controls');
+
+  restored.setSelectMode(false);
+  assert.strictEqual(
+    recorder.storage.has('cwm_terminal_select_mode_v1:session%2Fa'),
+    false,
+    'turning Select mode off must remove the saved preference'
+  );
+  assert.strictEqual(
+    new TerminalPane('x', 'session/a', 'Session A')._selectMode,
+    false,
+    'an explicit OFF choice must survive the next refresh'
+  );
+});
 
 /**
  * Compile the production app focus helper in isolation. Its body only calls


### PR DESCRIPTION
## Summary

- make explicit terminal Copy authoritative when embedded Chromium reports a
  truthy no-op `execCommand('copy')`
- keep the modern Clipboard API in the original trusted click, while retaining
  a verified synchronous fallback for insecure origins and permission denial
- restore terminal focus and selection before an asynchronous write settles,
  so immediate Ctrl+C works and later settlement cannot overwrite a newer
  selection
- remember Select mode per terminal session so a public-app refresh does not
  silently turn ordinary drag-to-select back into TUI mouse input
- force fresh terminal, app, and mirror assets with
  `20260727-copy-native8`

## Root causes

1. `document.execCommand('copy')` could return `true` without dispatching a
   copy event or changing the platform clipboard. Workbook treated that
   advisory boolean as success and skipped the working modern write.
2. Pointer-opened menu Copy restored xterm focus only after the clipboard
   promise settled. A slow permission prompt stranded Ctrl+C on `<body>` and
   could restore a stale selection over a newer one.
3. Select mode was always initialized to OFF. Refresh therefore changed the
   meaning of an ordinary terminal drag even when the user had explicitly
   enabled selection moments earlier.

## Verification

- `npm test`
- `npm run test:browser`
- copy fallback VM suite: 23/23
- Select/right-click suite: 23/23
- real Chromium secure and insecure origins
- full production Workbook shell with delayed Clipboard API settlement
- exact OS clipboard sentinels for Ctrl+C and right-click Copy
- real Chromium reload: Select mode remains ON for the same session, ordinary
  drag selects, and Ctrl+C copies the exact selection
- live lane GUI on `20260727-copy-native8`: refreshed mode restored; selected
  Ctrl+C copied exact text; right-click Copy and immediate follow-up Ctrl+C
  both copied exact ` 1. Yes, I trust this folder`
- `git diff --check`
- changed-diff high-signal secret scan: zero matches
- `npm pack --dry-run --json`: 94 files, 1,474,316 bytes

## Boundaries

- no npm publication
- no tunnel/config mutation or cloudflared restart
- no push to the read-only `origin` evidence remote
- no broad tag push

